### PR TITLE
Allow parsers to register themselves

### DIFF
--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -139,4 +139,6 @@ class FormatParser::DPXParser
       height_px: num_lines,
     )
   end
+
+  FormatParser.register_parser_constructor self
 end

--- a/lib/parsers/gif_parser.rb
+++ b/lib/parsers/gif_parser.rb
@@ -45,4 +45,6 @@ class FormatParser::GIFParser
       color_mode: :indexed,
     )
   end
+
+  FormatParser.register_parser_constructor self
 end

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -111,4 +111,6 @@ class FormatParser::JPEGParser
     length = read_short - 2
     advance(length)
   end
+
+  FormatParser.register_parser_constructor self
 end

--- a/lib/parsers/png_parser.rb
+++ b/lib/parsers/png_parser.rb
@@ -77,4 +77,6 @@ class FormatParser::PNGParser
       num_animation_or_video_frames: num_frames,
     )
   end
+
+  FormatParser.register_parser_constructor self
 end

--- a/lib/parsers/psd_parser.rb
+++ b/lib/parsers/psd_parser.rb
@@ -17,4 +17,6 @@ class FormatParser::PSDParser
       height_px: h,
     )
   end
+
+  FormatParser.register_parser_constructor self
 end

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -58,4 +58,5 @@ class FormatParser::TIFFParser
     [@width, @height]
   end
 
+  FormatParser.register_parser_constructor self
 end


### PR DESCRIPTION
so that we do not have to add explicit requires, and so that
an application using this library can add it's own parser
implementations/modules into the mix.

We keep the usage of .new in the parse method because the
method has to be reentrant - we have to ensure that it can
be called at the same time from multiple threads.