### PR TITLE
Parse magic_bytes and select parser per type

### DIFF
--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -139,5 +139,5 @@ class FormatParser::DPXParser
     )
   end
 
-  FormatParser.register_parser_constructor self
+  FormatParser.register_parser_constructor self, :dpx
 end

--- a/lib/parsers/gif_parser.rb
+++ b/lib/parsers/gif_parser.rb
@@ -45,5 +45,5 @@ class FormatParser::GIFParser
     )
   end
 
-  FormatParser.register_parser_constructor self
+  FormatParser.register_parser_constructor self, :gif
 end

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -115,5 +115,5 @@ class FormatParser::JPEGParser
     advance(length)
   end
 
-  FormatParser.register_parser_constructor self
+  FormatParser.register_parser_constructor self, :jpeg
 end

--- a/lib/parsers/png_parser.rb
+++ b/lib/parsers/png_parser.rb
@@ -79,5 +79,5 @@ class FormatParser::PNGParser
     )
   end
 
-  FormatParser.register_parser_constructor self
+  FormatParser.register_parser_constructor self, :png
 end

--- a/lib/parsers/psd_parser.rb
+++ b/lib/parsers/psd_parser.rb
@@ -17,5 +17,5 @@ class FormatParser::PSDParser
     )
   end
 
-  FormatParser.register_parser_constructor self
+  FormatParser.register_parser_constructor self, :psd
 end

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -66,5 +66,5 @@ class FormatParser::TIFFParser
     [@width, @height]
   end
 
-  FormatParser.register_parser_constructor self
+  FormatParser.register_parser_constructor self, :tiff
 end

--- a/wt_format_parser.gemspec
+++ b/wt_format_parser.gemspec
@@ -34,7 +34,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'exifr', '~> 1.0'
   spec.add_dependency 'faraday', '~> 0.13'
-  
+  spec.add_dependency 'magic_bytes', '~> 1.0'
+
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rake', '~> 12'
   spec.add_development_dependency 'simplecov', '~> 0.15'


### PR DESCRIPTION
Rather than trying all parsers on all files, we can use just the parser we want per file type. While this removes some flexibility (we can't get data from both a TIFF parser _and_ a CR2 parser) it optimises the code (the test suite runs in `~0.25` seconds as opposed to `~0.31` seconds 😉) and I'm confident we can follow Dimension's example and include some TIFF parsing code in the CR2 parser etc. 