### PR TITLE
Add IO methods required by exifr

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ file_info.width_px              #=> 320
 file_info.height_px             #=> 240
 file_info.orientation           #=> :top_left
 ```
+
 If nothing is detected, the result will be `nil`.
 
 ## Design rationale

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -36,8 +36,19 @@ class FormatParser::ReadLimiter
 
     @io.read(n)
   end
+  
+  # A particular implementation of read meant to make reading JPEG EXIF data
+  # easier on remote reads, but if we want to override the defaults and 
+  # use it somewhere else we can. (EXIFR expects just plain ol' readbyte so
+  # we have to include the defaults)
+  def readbyte(num_bytes_to_read: 1, unpack_code: "C")
+    @io.read(num_bytes_to_read).unpack(unpack_code).first
+  end
+  
+  # EXIFR requires a getbyte method that does exactly the same thing as readbyte
 
   def getbyte
-    @io.read(1).unpack("C").first
+    readbyte
   end
+  
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -38,6 +38,6 @@ class FormatParser::ReadLimiter
   end
 
   def getbyte
-    @io.read(1)
+    @io.read(1).unpack("C").first
   end
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -38,6 +38,6 @@ class FormatParser::ReadLimiter
   end
 
   def getbyte
-    @io.read(1).gsub('\\', '0')
+    @io.read(1)
   end
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -42,11 +42,10 @@ class FormatParser::ReadLimiter
   # use it somewhere else we can. (EXIFR expects just plain ol' readbyte so
   # we have to include the defaults)
   def readbyte(num_bytes_to_read: 1, unpack_code: "C")
-    @io.read(num_bytes_to_read).unpack(unpack_code).first
+    read(num_bytes_to_read).unpack(unpack_code).first
   end
   
   # EXIFR requires a getbyte method that does exactly the same thing as readbyte
-
   def getbyte
     readbyte
   end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -36,4 +36,8 @@ class FormatParser::ReadLimiter
 
     @io.read(n)
   end
+
+  def getbyte
+    @io.read(1).gsub('\\', '0')
+  end
 end

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -43,7 +43,7 @@ class FormatParser::RemoteIO
   def read(n_bytes)
     http_range = (@pos..(@pos + n_bytes - 1))
     @remote_size, body = request_range(http_range)
-    body.force_encoding(Encoding::BINARY) if body
+    body.force_encoding(Encoding::ASCII_8BIT) if body
     body
   end
 

--- a/spec/read_limiter_spec.rb
+++ b/spec/read_limiter_spec.rb
@@ -32,4 +32,20 @@ describe "ReadLimiter" do
       reader.read(1)
     }.to raise_error(/bytes budget \(512\) exceeded/)
   end
+
+  it 'enforces the number of bytes read with readbyte' do
+    reader = FormatParser::ReadLimiter.new(io, max_bytes: 512)
+    reader.readbyte(num_bytes_to_read: 512)
+    expect {
+      reader.readbyte(num_bytes_to_read: 1)
+    }.to raise_error(/bytes budget \(512\) exceeded/)
+  end
+
+  it 'enforces the number of reads with readbyte' do
+    reader = FormatParser::ReadLimiter.new(io, max_reads: 4)
+    4.times { reader.readbyte(num_bytes_to_read: 1) }
+    expect {
+      reader.readbyte(num_bytes_to_read: 1)
+    }.to raise_error(/calls exceeded \(4 max\)/)
+  end
 end

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -25,6 +25,12 @@ describe 'Fetching data from HTTP remotes' do
     expect(file_information.file_nature).to eq(:image)
   end
 
+  it 'parses the JPEGs exif data' do
+    file_information = FormatParser.parse_http('http://localhost:9399/exif-orientation-testimages/jpg/top_left.jpg')
+    expect(file_information).not_to be_nil
+    expect(file_information.file_nature).to eq(:image)
+  end
+
   after(:all) do
     @server.stop
     @server_thread.join(0.5)

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -41,6 +41,21 @@ describe 'Fetching data from HTTP remotes' do
     expect(file_information.orientation).to eq(:top_left)
   end
 
+  describe 'is able to correctly parse orientation for all remote JPEG EXIF examples from FastImage' do
+    Dir.glob(fixtures_dir + '/exif-orientation-testimages/jpg/*.jpg').each do |jpeg_path|
+      filename = File.basename(jpeg_path)
+      it "is able to parse #{filename}" do
+        remote_jpeg_path = jpeg_path.gsub("/Users/noah/Projects/format_parser/spec/fixtures/", "http://localhost:9399")
+        file_information = FormatParser.parse_http(remote_jpeg_path)
+        expect(file_information).not_to be_nil
+
+        expect(file_information.orientation).to be_kind_of(Symbol)
+        # Filenames in this dir correspond with the orientation of the file
+        expect(filename.include?(file_information.orientation.to_s)).to be true 
+      end
+    end
+  end
+  
   after(:all) do
     @server.stop
     @server_thread.join(0.5)

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -45,7 +45,7 @@ describe 'Fetching data from HTTP remotes' do
     Dir.glob(fixtures_dir + '/exif-orientation-testimages/jpg/*.jpg').each do |jpeg_path|
       filename = File.basename(jpeg_path)
       it "is able to parse #{filename}" do
-        remote_jpeg_path = jpeg_path.gsub("/Users/noah/Projects/format_parser/spec/fixtures/", "http://localhost:9399")
+        remote_jpeg_path = jpeg_path.gsub(fixtures_dir, "http://localhost:9399")
         file_information = FormatParser.parse_http(remote_jpeg_path)
         expect(file_information).not_to be_nil
 

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -29,6 +29,16 @@ describe 'Fetching data from HTTP remotes' do
     file_information = FormatParser.parse_http('http://localhost:9399/exif-orientation-testimages/jpg/top_left.jpg')
     expect(file_information).not_to be_nil
     expect(file_information.file_nature).to eq(:image)
+    expect(file_information.file_type).to eq(:jpg)
+    expect(file_information.orientation).to eq(:top_left)
+  end
+
+  it 'parses the TIFFs exif data' do
+    file_information = FormatParser.parse_http('http://localhost:9399/TIFF/test.tif')
+    expect(file_information).not_to be_nil
+    expect(file_information.file_nature).to eq(:image)
+    expect(file_information.file_type).to eq(:tif)
+    expect(file_information.orientation).to eq(:top_left)
   end
 
   after(:all) do


### PR DESCRIPTION
EXIFR kindly requests the presence of `getbyte` and `readbyte` IO methods, and here they are.