### PR TITLE
Introduce a restrictive IO subset wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ file_info.width_px              #=> 320
 file_info.height_px             #=> 240
 file_info.orientation           #=> :top_left
 ```
+
 If nothing is detected, the result will be `nil`.
 
 ## Design rationale

--- a/lib/care.rb
+++ b/lib/care.rb
@@ -12,6 +12,10 @@ class Care
       @pos = 0
     end
 
+    def size
+      @io.size
+    end
+
     def seek(to)
       @pos = to
     end

--- a/lib/care.rb
+++ b/lib/care.rb
@@ -20,6 +20,10 @@ class Care
       @pos = to
     end
 
+    def pos
+      @pos
+    end
+
     def read(n_bytes)
       read = @cache.byteslice(@io, @pos, n_bytes)
       return nil unless read && !read.empty?

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -5,6 +5,7 @@ module FormatParser
   require_relative 'io_utils'
   require_relative 'read_limiter'
   require_relative 'remote_io'
+  require_relative 'io_constraint'
   require_relative 'care'
 
   PARSER_MUX = Mutex.new

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -18,17 +18,22 @@ module FormatParser
   end
 
   def self.parse_http(url)
-    parse(RemoteIO.new(url))
-  end
-
-  def self.parse(io)
-    io = Care::IOWrapper.new(io) unless io.is_a?(Care::IOWrapper)
+    remote_io = RemoteIO.new(url)
+    cached_io = Care::IOWrapper.new(remote_io)
 
     # Prefetch the first page, since it is very likely to be touched
     # by all parsers anyway. Additionally, when using RemoteIO we need
-    # to obtain the size of the resource, which is only available
-    # after having performed the first GET - at least on S3
-    io.read(1); io.seek(0)
+    # to explicitly obtain the size of the resource, which is only available
+    # after having performed at least one successful GET - at least on S3
+    cached_io.read(1); cached_io.seek(0)
+
+    parse(cached_io)
+  end
+
+  def self.parse(io)
+    # If the cache is preconfigured do not apply an extra layer. It is going
+    # to be preconfigured when using parse_http.
+    io = Care::IOWrapper.new(io) unless io.is_a?(Care::IOWrapper)
 
     # Always instantiate parsers fresh for each input, since they might
     # contain instance variables which otherwise would have to be reset

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -24,6 +24,12 @@ module FormatParser
   def self.parse(io)
     io = Care::IOWrapper.new(io) unless io.is_a?(Care::IOWrapper)
 
+    # Prefetch the first page, since it is very likely to be touched
+    # by all parsers anyway. Additionally, when using RemoteIO we need
+    # to obtain the size of the resource, which is only available
+    # after having performed the first GET - at least on S3
+    io.read(1); io.seek(0)
+
     # Always instantiate parsers fresh for each input, since they might
     # contain instance variables which otherwise would have to be reset
     # between invocations, and would complicate threading situations

--- a/lib/io_constraint.rb
+++ b/lib/io_constraint.rb
@@ -30,4 +30,8 @@ class FormatParser::IOConstraint
   def size
     @io.size
   end
+
+  def pos
+    @io.pos
+  end
 end

--- a/lib/io_constraint.rb
+++ b/lib/io_constraint.rb
@@ -8,6 +8,12 @@
 # nothing more. Consequently, if the parser uses a gem that
 # for some reason needs additional IO methods to be available
 # this parser has to provide it's own extensions to that end.
+#
+# The rationale for including a method in this subset is as follows:
+# we include a method if other methods can be implemented on top of it.
+# For example, should some parser desire `IO#readbyte`, it can be
+# implemented in terms of a `read()`. Idem for things like `IO#eof?`,
+# `IO#rewind` and friends.
 class FormatParser::IOConstraint
   def initialize(io)
     @io = io

--- a/lib/io_constraint.rb
+++ b/lib/io_constraint.rb
@@ -1,0 +1,27 @@
+# We deliberately want to document and restrict the
+# number of methods an IO-ish object has to implement
+# to be usable with all our parsers. This subset is fairly
+# thin and well defined, and all the various IO limiters
+# and cache facilities in the library are guaranteed to
+# support those methods. This wrapper is used to guarantee
+# that the parser can only call those specific methods and
+# nothing more. Consequently, if the parser uses a gem that
+# for some reason needs additional IO methods to be available
+# this parser has to provide it's own extensions to that end.
+class FormatParser::IOConstraint
+  def initialize(io)
+    @io = io
+  end
+  
+  def read(n_bytes)
+    @io.read(n_bytes)
+  end
+  
+  def seek(absolute_offset)
+    @io.seek(absolute_offset)
+  end
+  
+  def size
+    @io.size
+  end
+end

--- a/lib/parsers/aiff_parser.rb
+++ b/lib/parsers/aiff_parser.rb
@@ -19,7 +19,7 @@ class FormatParser::AIFFParser
   ]
 
   def information_from_io(io)
-    io.seek(0)
+    io = FormatParser::IOConstraint.new(io)
     form_chunk_type, chunk_size = safe_read(io, 8).unpack('a4N')
     return unless form_chunk_type == "FORM" && chunk_size > 4
 

--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -125,6 +125,7 @@ class FormatParser::DPXParser
   HEADER_SIZE = SIZEOF[DPX_INFO] # Does not include the initial 4 bytes
 
   def information_from_io(io)
+    io = FormatParser::IOConstraint.new(io)
     magic = io.read(4)
 
     return nil unless [BE_MAGIC, LE_MAGIC].include?(magic)

--- a/lib/parsers/exif_parser.rb
+++ b/lib/parsers/exif_parser.rb
@@ -21,9 +21,9 @@ class FormatParser::EXIFParser
     :left_bottom
   ]
 
-  def initialize(filetype, file_data)
+  def initialize(filetype, file_io)
     @filetype = filetype
-    @file_data = file_data
+    @file_io = file_io
     @exif_data = nil
     @orientation = nil
     @height = nil
@@ -31,11 +31,10 @@ class FormatParser::EXIFParser
   end
 
   def scan_image_exif
-
     # Without the magic bytes EXIFR throws an error
-    @file_data.seek(0)
-    raw_exif_data = EXIFR::JPEG.new(@file_data) if @filetype == :jpeg
-    raw_exif_data = EXIFR::TIFF.new(@file_data) if @filetype == :tiff
+    @file_io.seek(0)
+    raw_exif_data = EXIFR::JPEG.new(@file_io) if @filetype == :jpeg
+    raw_exif_data = EXIFR::TIFF.new(@file_io) if @filetype == :tiff
     # For things that we don't yet have a parser for
     # we make the raw exif result available
     @exif_data = raw_exif_data

--- a/lib/parsers/gif_parser.rb
+++ b/lib/parsers/gif_parser.rb
@@ -5,6 +5,8 @@ class FormatParser::GIFParser
   include FormatParser::IOUtils
 
   def information_from_io(io)
+    io = FormatParser::IOConstraint.new(io)
+
     header = safe_read(io, 6)
     return unless HEADERS.include?(header)
 

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -11,7 +11,7 @@ class FormatParser::JPEGParser
   APP1_MARKER = 0xE1  # maybe EXIF
 
   def information_from_io(io)
-    @buf = io
+    @buf = FormatParser::IOConstraint.new(io)
     @width             = nil
     @height            = nil
     @orientation       = nil

--- a/lib/parsers/png_parser.rb
+++ b/lib/parsers/png_parser.rb
@@ -19,8 +19,9 @@ class FormatParser::PNGParser
     safe_read(io, 8).unpack("Na4")
   end
 
-
   def information_from_io(io)
+    io = FormatParser::IOConstraint.new(io)
+
     magic_bytes = safe_read(io, PNG_HEADER_BYTES.bytesize)
     return unless magic_bytes == PNG_HEADER_BYTES
 

--- a/lib/parsers/psd_parser.rb
+++ b/lib/parsers/psd_parser.rb
@@ -3,6 +3,8 @@ class FormatParser::PSDParser
   include FormatParser::IOUtils
 
   def information_from_io(io)
+    io = FormatParser::IOConstraint.new(io)
+
     magic_bytes = safe_read(io, 4).unpack("C4")
 
     return unless magic_bytes == PSD_HEADER

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -7,6 +7,8 @@ class FormatParser::TIFFParser
   include FormatParser::IOUtils
 
   def information_from_io(io)
+    io = FormatParser::IOConstraint.new(io)
+
     magic_bytes = safe_read(io, 4).unpack("C4")
     endianness = scan_tiff_endianness(magic_bytes)
     return unless endianness

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -36,8 +36,19 @@ class FormatParser::ReadLimiter
 
     @io.read(n)
   end
+  
+  # A particular implementation of read meant to make reading JPEG EXIF data
+  # easier on remote reads, but if we want to override the defaults and 
+  # use it somewhere else we can. (EXIFR expects just plain ol' readbyte so
+  # we have to include the defaults)
+  def readbyte(num_bytes_to_read: 1, unpack_code: "C")
+    @io.read(num_bytes_to_read).unpack(unpack_code).first
+  end
+  
+  # EXIFR requires a getbyte method that does exactly the same thing as readbyte
 
   def getbyte
-    @io.read(1).unpack("C").first
+    readbyte
   end
+  
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -38,6 +38,6 @@ class FormatParser::ReadLimiter
   end
 
   def getbyte
-    @io.read(1)
+    @io.read(1).unpack("C").first
   end
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -18,6 +18,10 @@ class FormatParser::ReadLimiter
     @io.size
   end
 
+  def pos
+    @io.pos
+  end
+
   def seek(to_offset)
     @seeks += 1
     if @max_seeks && @seeks > @max_seeks

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -14,6 +14,10 @@ class FormatParser::ReadLimiter
     @bytes = 0
   end
 
+  def size
+    @io.size
+  end
+
   def seek(to_offset)
     @seeks += 1
     if @max_seeks && @seeks > @max_seeks

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -38,6 +38,6 @@ class FormatParser::ReadLimiter
   end
 
   def getbyte
-    @io.read(1).gsub('\\', '0')
+    @io.read(1)
   end
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -42,11 +42,10 @@ class FormatParser::ReadLimiter
   # use it somewhere else we can. (EXIFR expects just plain ol' readbyte so
   # we have to include the defaults)
   def readbyte(num_bytes_to_read: 1, unpack_code: "C")
-    @io.read(num_bytes_to_read).unpack(unpack_code).first
+    read(num_bytes_to_read).unpack(unpack_code).first
   end
   
   # EXIFR requires a getbyte method that does exactly the same thing as readbyte
-
   def getbyte
     readbyte
   end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -36,4 +36,8 @@ class FormatParser::ReadLimiter
 
     @io.read(n)
   end
+
+  def getbyte
+    @io.read(1).gsub('\\', '0')
+  end
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -36,18 +36,4 @@ class FormatParser::ReadLimiter
 
     @io.read(n)
   end
-  
-  # A particular implementation of read meant to make reading JPEG EXIF data
-  # easier on remote reads, but if we want to override the defaults and 
-  # use it somewhere else we can. (EXIFR expects just plain ol' readbyte so
-  # we have to include the defaults)
-  def readbyte(num_bytes_to_read: 1, unpack_code: "C")
-    read(num_bytes_to_read).unpack(unpack_code).first
-  end
-  
-  # EXIFR requires a getbyte method that does exactly the same thing as readbyte
-  def getbyte
-    readbyte
-  end
-  
 end

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -24,6 +24,11 @@ class FormatParser::RemoteIO
     0 # always return 0
   end
 
+  # Emulates IO#pos
+  def pos
+    @pos
+  end
+
   # Emulates IO#size.
   #
   # @return [Integer] the size of the remote resource
@@ -45,6 +50,7 @@ class FormatParser::RemoteIO
     maybe_size, maybe_body = request_range(http_range)
     if maybe_size && maybe_body
       @remote_size = maybe_size
+      @pos += maybe_body.bytesize
       maybe_body.force_encoding(Encoding::ASCII_8BIT)
     else
       nil

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -43,7 +43,7 @@ class FormatParser::RemoteIO
   def read(n_bytes)
     http_range = (@pos..(@pos + n_bytes - 1))
     @remote_size, body = request_range(http_range)
-    body.force_encoding(Encoding::BINARY) if body
+    body.force_encoding(Encoding::ASCII_8BIT) if body
     body
   end
 

--- a/spec/care_spec.rb
+++ b/spec/care_spec.rb
@@ -46,6 +46,8 @@ describe Care do
   end
 
   describe Care::IOWrapper do
+    it_behaves_like 'an IO object compatible with IOConstraint'
+
     it 'forwards calls to read() to the Care and adjusts internal offsets' do
       fake_cache_class = Class.new do
         attr_reader :recorded_calls
@@ -74,6 +76,11 @@ describe Care do
       expect(third).to eq([io_double,  11, 5])
     end
 
+    it 'implements the complete subset of IOConstraint' do
+      methods_not_covered = Set.new(FormatParser::IOConstraint.public_instance_methods) - Set.new(Care::IOWrapper.public_instance_methods)
+      expect(methods_not_covered).to be_empty
+    end
+    
     it 'forwards calls to size() to the underlying IO' do
       io_double = double('IO')
       expect(io_double).to receive(:size).and_return(123)

--- a/spec/care_spec.rb
+++ b/spec/care_spec.rb
@@ -73,5 +73,13 @@ describe Care do
       expect(second).to eq([io_double, 2, 3])
       expect(third).to eq([io_double,  11, 5])
     end
+
+    it 'forwards calls to size() to the underlying IO' do
+      io_double = double('IO')
+      expect(io_double).to receive(:size).and_return(123)
+
+      subject = Care::IOWrapper.new(io_double)
+      expect(subject.size).to eq(123)
+    end
   end
 end

--- a/spec/read_limiter_spec.rb
+++ b/spec/read_limiter_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 describe "ReadLimiter" do
   let(:io) { StringIO.new(Random.new.bytes(1024)) }
 
+  it 'implements the complete subset of IOConstraint' do
+    reader = FormatParser::ReadLimiter.new(io)
+    methods_not_covered = Set.new(FormatParser::IOConstraint.public_instance_methods) - Set.new(reader.public_methods)
+    expect(methods_not_covered).to be_empty
+  end
+
   it 'does not enforce any limits with default arguments' do
     reader = FormatParser::ReadLimiter.new(io)
     2048.times { reader.seek(1) }
@@ -33,19 +39,4 @@ describe "ReadLimiter" do
     }.to raise_error(/bytes budget \(512\) exceeded/)
   end
 
-  it 'enforces the number of bytes read with readbyte' do
-    reader = FormatParser::ReadLimiter.new(io, max_bytes: 512)
-    reader.readbyte(num_bytes_to_read: 512)
-    expect {
-      reader.readbyte(num_bytes_to_read: 1)
-    }.to raise_error(/bytes budget \(512\) exceeded/)
-  end
-
-  it 'enforces the number of reads with readbyte' do
-    reader = FormatParser::ReadLimiter.new(io, max_reads: 4)
-    4.times { reader.readbyte(num_bytes_to_read: 1) }
-    expect {
-      reader.readbyte(num_bytes_to_read: 1)
-    }.to raise_error(/calls exceeded \(4 max\)/)
-  end
 end

--- a/spec/read_limiter_spec.rb
+++ b/spec/read_limiter_spec.rb
@@ -11,6 +11,13 @@ describe FormatParser::ReadLimiter do
     2048.times { reader.read(4) }
   end
 
+  it 'passes #pos to the delegate' do
+    reader = FormatParser::ReadLimiter.new(io)
+    expect(reader.pos).to eq(0)
+    io.read(2)
+    expect(reader.pos).to eq(2)
+  end
+
   it 'enforces the number of seeks' do
     reader = FormatParser::ReadLimiter.new(io, max_seeks: 4)
     4.times { reader.seek(1) }

--- a/spec/read_limiter_spec.rb
+++ b/spec/read_limiter_spec.rb
@@ -32,4 +32,20 @@ describe "ReadLimiter" do
       reader.read(1)
     }.to raise_error(/bytes budget \(512\) exceeded/)
   end
+
+  it 'enforces the number of bytes read with readbyte' do
+    reader = FormatParser::ReadLimiter.new(io, max_bytes: 512)
+    reader.readbyte(num_bytes_to_read: 512)
+    expect {
+      reader.readbyte(num_bytes_to_read: 1)
+    }.to raise_error(/bytes budget \(512\) exceeded/)
+  end
+
+  it 'enforces the number of reads with readbyte' do
+    reader = FormatParser::ReadLimiter.new(io, max_reads: 4)
+    4.times { reader.readbyte(num_bytes_to_read: 1) }
+    expect {
+      reader.readbyte(num_bytes_to_read: 1)
+    }.to raise_error(/calls exceeded \(4 max\)/)
+  end
 end

--- a/spec/read_limiter_spec.rb
+++ b/spec/read_limiter_spec.rb
@@ -1,13 +1,9 @@
 require 'spec_helper'
 
-describe "ReadLimiter" do
+describe FormatParser::ReadLimiter do
   let(:io) { StringIO.new(Random.new.bytes(1024)) }
 
-  it 'implements the complete subset of IOConstraint' do
-    reader = FormatParser::ReadLimiter.new(io)
-    methods_not_covered = Set.new(FormatParser::IOConstraint.public_instance_methods) - Set.new(reader.public_methods)
-    expect(methods_not_covered).to be_empty
-  end
+  it_behaves_like 'an IO object compatible with IOConstraint'
 
   it 'does not enforce any limits with default arguments' do
     reader = FormatParser::ReadLimiter.new(io)

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -25,6 +25,12 @@ describe 'Fetching data from HTTP remotes' do
     expect(file_information.file_nature).to eq(:image)
   end
 
+  it 'parses the JPEGs exif data' do
+    file_information = FormatParser.parse_http('http://localhost:9399/exif-orientation-testimages/jpg/top_left.jpg')
+    expect(file_information).not_to be_nil
+    expect(file_information.file_nature).to eq(:image)
+  end
+
   after(:all) do
     @server.stop
     @server_thread.join(0.5)

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -41,6 +41,21 @@ describe 'Fetching data from HTTP remotes' do
     expect(file_information.orientation).to eq(:top_left)
   end
 
+  describe 'is able to correctly parse orientation for all remote JPEG EXIF examples from FastImage' do
+    Dir.glob(fixtures_dir + '/exif-orientation-testimages/jpg/*.jpg').each do |jpeg_path|
+      filename = File.basename(jpeg_path)
+      it "is able to parse #{filename}" do
+        remote_jpeg_path = jpeg_path.gsub("/Users/noah/Projects/format_parser/spec/fixtures/", "http://localhost:9399")
+        file_information = FormatParser.parse_http(remote_jpeg_path)
+        expect(file_information).not_to be_nil
+
+        expect(file_information.orientation).to be_kind_of(Symbol)
+        # Filenames in this dir correspond with the orientation of the file
+        expect(filename.include?(file_information.orientation.to_s)).to be true 
+      end
+    end
+  end
+  
   after(:all) do
     @server.stop
     @server_thread.join(0.5)

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -45,7 +45,7 @@ describe 'Fetching data from HTTP remotes' do
     Dir.glob(fixtures_dir + '/exif-orientation-testimages/jpg/*.jpg').each do |jpeg_path|
       filename = File.basename(jpeg_path)
       it "is able to parse #{filename}" do
-        remote_jpeg_path = jpeg_path.gsub("/Users/noah/Projects/format_parser/spec/fixtures/", "http://localhost:9399")
+        remote_jpeg_path = jpeg_path.gsub(fixtures_dir, "http://localhost:9399")
         file_information = FormatParser.parse_http(remote_jpeg_path)
         expect(file_information).not_to be_nil
 

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -29,6 +29,16 @@ describe 'Fetching data from HTTP remotes' do
     file_information = FormatParser.parse_http('http://localhost:9399/exif-orientation-testimages/jpg/top_left.jpg')
     expect(file_information).not_to be_nil
     expect(file_information.file_nature).to eq(:image)
+    expect(file_information.file_type).to eq(:jpg)
+    expect(file_information.orientation).to eq(:top_left)
+  end
+
+  it 'parses the TIFFs exif data' do
+    file_information = FormatParser.parse_http('http://localhost:9399/TIFF/test.tif')
+    expect(file_information).not_to be_nil
+    expect(file_information.file_nature).to eq(:image)
+    expect(file_information.file_type).to eq(:tif)
+    expect(file_information.orientation).to eq(:top_left)
   end
 
   after(:all) do

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe FormatParser::RemoteIO do
 
+  it_behaves_like 'an IO object compatible with IOConstraint'
+
   it 'returns the partial content when the server supplies a 206 status' do
     rio = described_class.new("https://images.invalid/img.jpg")
     

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -73,4 +73,16 @@ describe FormatParser::RemoteIO do
     rio.seek(100)
     expect { rio.read(100) }.to raise_error(/replied with a 502 and we might want to retry/)
   end
+
+  it 'maintains and exposes #pos' do
+    rio = described_class.new("https://images.invalid/img.jpg")
+
+    expect(rio.pos).to eq(0)
+
+    fake_resp = double(headers: {'Content-Range' => 'bytes 0-0/13'}, status: 206, body: 'a')
+    expect(Faraday).to receive(:get).with("https://images.invalid/img.jpg", nil, range: "bytes=0-0").and_return(fake_resp)
+    rio.read(1)
+
+    expect(rio.pos).to eq(1)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,12 @@ RSpec.configure do |c|
   c.include SpecHelpers
   c.extend SpecHelpers # makes fixtures_dir available for example groups too
 end
+
+RSpec.shared_examples "an IO object compatible with IOConstraint" do
+  it 'responds to the same subset of public instance methods' do
+    requisite_methods = FormatParser::IOConstraint.public_instance_methods - Object.public_instance_methods
+    requisite_methods.each do |requisite|
+      expect(described_class.public_instance_methods).to include(requisite), "#{described_class} must respond to #{requisite}"
+    end
+  end
+end


### PR DESCRIPTION
When setting up the IO stack for this library I deliberately reduced the subset of the IO API that we require to be available. This serves two goals: it's possible to feed separate parsers StringIOs and File objects directly, and it makes the proxies we have to make to limit reads, implement caching and so forth thinner. This change ensures we are only able to call the methods our IO wrappers actually support, regardless whether the parser is getting a File, a RemoteIO or one of our cache/limiters. This replaces #38 so that we can proceed to some more interesting business. For the examples of what wants `size` - ID3v1 tags are at the end of the file, as well as the ZIP central directory etc. 