### PR TITLE
Use Hashes for MOOV atom data fields, remove repack()

### DIFF
--- a/lib/parsers/moov_parser/decoder.rb
+++ b/lib/parsers/moov_parser/decoder.rb
@@ -50,7 +50,7 @@ class FormatParser::MOOVParser::Decoder
     # numbr of bytes is reserved for the compatible brands, 4 bytes per
     # brand.
     num_brands = (atom_size - 8 - 8) / 4
-    ret = {
+    {
       major_brand: read_bytes(io, 4),
       minor_version: read_binary_coded_decimal(io),
       compatible_brands: (1..num_brands).map { read_bytes(io, 4) },
@@ -60,94 +60,88 @@ class FormatParser::MOOVParser::Decoder
   def parse_tkhd_atom(io, _)
     version = read_byte_value(io)
     is_v1 = version == 1
-    tkhd_info_bites = [
-      :version, version,
-      :flags, read_chars(io, 3),
-      :ctime, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :mtime, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :trak_id, read_32bit_uint(io),
-      :reserved_1, read_chars(io, 4),
-      :duration, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :reserved_2, read_chars(io, 8),
-      :layer, read_16bit_uint(io),
-      :alternate_group, read_16bit_uint(io),
-      :volume, read_16bit_uint(io),
-      :reserved_3, read_chars(io, 2),
-      :matrix_structure, (1..9).map { read_32bit_fixed_point(io) },
-      :track_width, read_32bit_fixed_point(io),
-      :track_height, read_32bit_fixed_point(io),
-    ]
-    repack(tkhd_info_bites)
+    {
+      version: version,
+      flags: read_chars(io, 3),
+      ctime: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      mtime: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      trak_id: read_32bit_uint(io),
+      reserved_1: read_chars(io, 4),
+      duration: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      reserved_2: read_chars(io, 8),
+      layer: read_16bit_uint(io),
+      alternate_group: read_16bit_uint(io),
+      volume: read_16bit_uint(io),
+      reserved_3: read_chars(io, 2),
+      matrix_structure: (1..9).map { read_32bit_fixed_point(io) },
+      track_width: read_32bit_fixed_point(io),
+      track_height: read_32bit_fixed_point(io),
+    }
   end
 
   def parse_mdhd_atom(io, _)
     version = read_byte_value(io)
     is_v1 = version == 1
-    mdhd_info_bites = [
-      :version, version,
-      :flags, read_bytes(io, 3),
-      :ctime, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :mtime, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :tscale, read_32bit_uint(io),
-      :duration, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :language, read_32bit_uint(io),
-      :quality, read_32bit_uint(io),
-    ]
-    repack(mdhd_info_bites)
+    {
+      version: version,
+      flags: read_bytes(io, 3),
+      ctime: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      mtime: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      tscale: read_32bit_uint(io),
+      duration: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      language: read_32bit_uint(io),
+      quality: read_32bit_uint(io),
+    }
   end
 
   def parse_vmhd_atom(io, _)
-    vmhd_info_bites = [
-      :version, read_byte_value(io),
-      :flags, read_bytes(io, 3),
-      :graphics_mode, read_bytes(io, 2),
-      :opcolor_r, read_32bit_uint(io),
-      :opcolor_g, read_32bit_uint(io),
-      :opcolor_b, read_32bit_uint(io),
-    ]
-    repack(vmhd_info_bites)
+    {
+      version: read_byte_value(io),
+      flags: read_bytes(io, 3),
+      graphics_mode: read_bytes(io, 2),
+      opcolor_r: read_32bit_uint(io),
+      opcolor_g: read_32bit_uint(io),
+      opcolor_b: read_32bit_uint(io),
+    }
   end
 
   def parse_mvhd_atom(io, _)
     version = read_byte_value(io)
     is_v1 = version == 1
-    mvhd_info_bites = [
-      :version, version,
-      :flags, read_bytes(io, 3),
-      :ctime, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :mtime, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :tscale, read_32bit_uint(io),
-      :duration, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-      :preferred_rate, read_32bit_uint(io),
-      :reserved, read_bytes(io, 10),
-      :matrix_structure, (1..9).map { read_32bit_fixed_point(io) },
-      :preview_time, read_32bit_uint(io),
-      :preview_duration, read_32bit_uint(io),
-      :poster_time, read_32bit_uint(io),
-      :selection_time, read_32bit_uint(io),
-      :selection_duration, read_32bit_uint(io),
-      :current_time, read_32bit_uint(io),
-      :next_trak_id, read_32bit_uint(io),
-    ]
-    repack(mvhd_info_bites)
+    {
+      version: version,
+      flags: read_bytes(io, 3),
+      ctime: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      mtime: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      tscale: read_32bit_uint(io),
+      duration: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+      preferred_rate: read_32bit_uint(io),
+      reserved: read_bytes(io, 10),
+      matrix_structure: (1..9).map { read_32bit_fixed_point(io) },
+      preview_time: read_32bit_uint(io),
+      preview_duration: read_32bit_uint(io),
+      poster_time: read_32bit_uint(io),
+      selection_time: read_32bit_uint(io),
+      selection_duration: read_32bit_uint(io),
+      current_time: read_32bit_uint(io),
+      next_trak_id: read_32bit_uint(io),
+    }
   end
 
   def parse_dref_atom(io, _)
-    dref_info_bites = [
-      :version, read_byte_value(io),
-      :flags, read_bytes(io, 3),
-      :num_entries, read_32bit_uint(io),
-    ]
-    dict = repack(dref_info_bites)
+    dict = {
+      version: read_byte_value(io),
+      flags: read_bytes(io, 3),
+      num_entries: read_32bit_uint(io),
+    }
     num_entries = dict[:num_entries]
     entries = (1..num_entries).map do
-      dref_entry_bites = [
-        :size, read_32bit_uint(io),
-        :type, read_bytes(io, 4),
-        :version, read_bytes(io, 1),
-        :flags, read_bytes(io, 3),
-      ]
-      entry = repack(dref_entry_bites)
+      entry = {
+        size: read_32bit_uint(io),
+        type: read_bytes(io, 4),
+        version: read_bytes(io, 1),
+        flags: read_bytes(io, 3),
+      }
       entry[:data] = read_bytes(io, entry[:size] - 12)
       entry
     end
@@ -156,21 +150,19 @@ class FormatParser::MOOVParser::Decoder
   end
 
   def parse_elst_atom(io, _)
-    elst_info_bites = [
-      :version, read_byte_value(io),
-      :flags, read_bytes(io, 3),
-      :num_entries, read_32bit_uint(io),
-    ]
-    dict = repack(elst_info_bites)
+    dict = {
+      version: read_byte_value(io),
+      flags: read_bytes(io, 3),
+      num_entries: read_32bit_uint(io),
+    }
     is_v1 = dict[:version] == 1 # Usual is 0, version 1 has 64bit durations
     num_entries = dict[:num_entries]
     entries = (1..num_entries).map do
-      entry_bites = [
-        :track_duration, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-        :media_time, is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
-        :media_rate, read_32bit_uint(io),
-      ]
-      repack(entry_bites)
+      {
+        track_duration: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+        media_time: is_v1 ? read_64bit_uint(io) : read_32bit_uint(io),
+        media_rate: read_32bit_uint(io),
+      }
     end
     dict[:entries] = entries
     dict
@@ -178,17 +170,16 @@ class FormatParser::MOOVParser::Decoder
 
   def parse_hdlr_atom(io, atom_size)
     sub_io = StringIO.new(io.read(atom_size - 8))
-    hdlr_info_bites = [
-      :version, read_byte_value(sub_io),
-      :flags, read_bytes(sub_io, 3),
-      :component_type, read_bytes(sub_io, 4),
-      :component_subtype, read_bytes(sub_io, 4),
-      :component_manufacturer, read_bytes(sub_io, 4),
-      :component_flags, read_bytes(sub_io, 4),
-      :component_flags_mask, read_bytes(sub_io, 4),
-      :component_name, sub_io.read,
-    ]
-    repack(hdlr_info_bites)
+    {
+      version: read_byte_value(sub_io),
+      flags: read_bytes(sub_io, 3),
+      component_type: read_bytes(sub_io, 4),
+      component_subtype: read_bytes(sub_io, 4),
+      component_manufacturer: read_bytes(sub_io, 4),
+      component_flags: read_bytes(sub_io, 4),
+      component_flags_mask: read_bytes(sub_io, 4),
+      component_name: sub_io.read,
+    }
   end
 
   def parse_atom_fields_per_type(io, atom_size, atom_type)
@@ -276,10 +267,5 @@ class FormatParser::MOOVParser::Decoder
     bcd_string = io.read(4)
     bcd_string.insert(0, '0') if bcd_string.length.odd?
     [bcd_string].pack('H*').unpack('C*')
-  end
-
-  def repack(properties_to_packspecs)
-    keys, bytes = properties_to_packspecs.partition.with_index { |_, i| i.even? }
-    Hash[keys.zip(bytes)]
   end
 end

--- a/lib/parsers/moov_parser/decoder.rb
+++ b/lib/parsers/moov_parser/decoder.rb
@@ -265,7 +265,6 @@ class FormatParser::MOOVParser::Decoder
 
   def read_binary_coded_decimal(io)
     bcd_string = io.read(4)
-    bcd_string.insert(0, '0') if bcd_string.length.odd?
     [bcd_string].pack('H*').unpack('C*')
   end
 end


### PR DESCRIPTION
The syntax for specifying an interspersed Array of field names and unpack patterns for each field is a neat hack but it doesn't help readability. Additionally, although Ruby's `unpack` is quite flexible and neat, it does not support groups. I.e. it is not possible to do this:

```
fields_and_patterns = [
  :width_height_and_depth, 'N1N1C',
  :icc_profile_name, 'a15',
]
```

The idea behind that syntax usage was to call `join` on the array of pack specifiers and be able to call into Ruby's `unpack` only once. This works for simple cases but in the MOOV parser it hurts readability - and Rubocop will complain.

Therefore I think we should ditch that syntax and just do the damn hashes.