### PR TITLE
Add require 'set' to format_parser.rb

### DIFF
--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -1,4 +1,5 @@
 module FormatParser
+  require 'set'
   require_relative 'image'
   require_relative 'audio'
   require_relative 'document'
@@ -8,7 +9,6 @@ module FormatParser
   require_relative 'remote_io'
   require_relative 'io_constraint'
   require_relative 'care'
-  require 'set'
 
   PARSER_MUX = Mutex.new
 

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -8,6 +8,7 @@ module FormatParser
   require_relative 'remote_io'
   require_relative 'io_constraint'
   require_relative 'care'
+  require 'set'
 
   PARSER_MUX = Mutex.new
 


### PR DESCRIPTION
When requiring/loading the format_parser gem, it crashes because `set` wasn't required in the format_parser.rb file.

This fixes the problem of the format_parser gem crashing on require/load:

```
irb(main):001:0> require 'format_parser'
NameError: uninitialized constant FormatParser::Set
```

I was stuck on this part for some time and asked for help from @tombruijn who fixed this. I implemented the fix and installed the gem in a Rails project of mine.
I learned this most likely didn't stand out, because other gems (such as Rails) may require it before this gem is loaded and bundler requires `set` as well 

[https://github.com/bundler/bundler/search?utf8=%E2%9C%93&q=%22require+set%22&type= ](url)