### PR TITLE
Add as_json method in image.rb

### DIFF
--- a/lib/image.rb
+++ b/lib/image.rb
@@ -1,5 +1,6 @@
 module FormatParser
   class Image
+
     NATURE = :image
 
     # What filetype was recognized? Will contain a non-ambiguous symbol
@@ -44,13 +45,24 @@ module FormatParser
     # it can be placed here
     attr_accessor :intrinsics
 
+    @@attributes = [ :format, :width_px, :height_px, :has_multiple_frames, :orientation, :has_transparency, :color_mode,
+                    :num_animation_or_video_frames, :image_orientation, :intrinsics ]
+
     # Only permits assignments via defined accessors
     def initialize(**attributes)
       attributes.map { |(k, v)| public_send("#{k}=", v) }
     end
 
+
+    def as_json(*attributes)
+      @@attributes.each_with_object({}) do |attribute, object|
+        object[attribute] = public_send(attribute)
+      end
+    end
+
     def nature
       NATURE
     end
+
   end
 end


### PR DESCRIPTION
Add `as_json` method to the Image.rb file which returns all the attributes. 

### Project
To build a default FileInformation#as_json (#40) I started with an implementation for the 
Image file information object.

### Challenges
-I spent some time looking for a way to call all the attributes within the Image Class and found a way by calling `@@attributes` 
-Writing a method that would omit all the attributes that have readers and are `nil` is a tough cookie and is still something I'm working on. 
-Writing specs is challenging. I need more time (and help) to dive deeper into RSpec to improve my TDD skills. This was taking a lot of time so I decided to write the method first. 

### Learnings
-Difference between `to_json` and `as_json`
-Calling (all) attributes in a class (I still have a ton of questions)
