### PR TITLE
Add default as_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ You can also optimize the metadata extraction by providing hints to the gem:
 FormatParser.parse(File.open("myimage", "rb"), natures: [:video, :image], formats: [:jpg, :png, :mp4], results: :all)
 ```
 
+If you need format_parser to return JSON, you can use `.as_json` to achieve this:
+
+```ruby
+class Foo
+  include AttributesJSON
+  attr_accessor :number_of_bars
+end
+
+the_foo = Foo.new
+the_foo.number_of_bars = 42
+the_foo.as_json #=> {:number_of_bars => 42}
+```
+
 ## Creating your own parsers
 
 In order to create new parsers, you have to write a method or a  Proc that accepts an IO and performs the

--- a/lib/attributes_json.rb
+++ b/lib/attributes_json.rb
@@ -1,0 +1,28 @@
+# Implements as_json as returning a Hash
+# containing the return values of all the
+# reader methods of an object that have
+# associated pair writer methods.
+#
+#   class Foo
+#     include AttributesJSON
+#     attr_accessor :number_of_bars
+#   end
+#   the_foo = Foo.new
+#   the_foo.number_of_bars = 42
+#   the_foo.as_json #=> {:number_of_bars => 42}
+module FormatParser::AttributesJSON
+
+  # Implements a sane default `as_json` for an object
+  # that accessors defined
+  def as_json(*_maybe_root_option)
+    h = {}
+    h['nature'] = nature if respond_to?(:nature) # Needed for file info structs
+    methods.grep(/\w\=$/).each_with_object(h) do |attr_writer_method_name, h|
+      reader_method_name = attr_writer_method_name.to_s.gsub(/\=$/, '')
+      value = public_send(reader_method_name)
+      # When calling as_json on our members there is no need to pass the root: option given to us
+      # by the caller
+      h[reader_method_name] = value.respond_to?(:as_json) ? value.as_json : value
+    end
+  end
+end

--- a/lib/audio.rb
+++ b/lib/audio.rb
@@ -1,5 +1,7 @@
 module FormatParser
   class Audio
+    include FormatParser::AttributesJSON
+
     NATURE = :audio
 
     # Type of the file (e.g :mp3)

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -1,5 +1,7 @@
 module FormatParser
   class Document
+    include FormatParser::AttributesJSON
+
     NATURE = :document
 
     attr_accessor :format

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -1,6 +1,7 @@
 require 'set'
 
 module FormatParser
+  require_relative 'attributes_json'
   require_relative 'image'
   require_relative 'audio'
   require_relative 'document'

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -1,5 +1,6 @@
+require 'set'
+
 module FormatParser
-  require 'set'
   require_relative 'image'
   require_relative 'audio'
   require_relative 'document'

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/lib/image.rb
+++ b/lib/image.rb
@@ -1,5 +1,7 @@
 module FormatParser
   class Image
+    include FormatParser::AttributesJSON
+
     NATURE = :image
 
     # What filetype was recognized? Will contain a non-ambiguous symbol

--- a/lib/video.rb
+++ b/lib/video.rb
@@ -1,5 +1,7 @@
 module FormatParser
   class Video
+    include FormatParser::AttributesJSON
+
     NATURE = :video
 
     attr_accessor :width_px

--- a/spec/attributes_json_spec.rb
+++ b/spec/attributes_json_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe FormatParser::AttributesJSON do
+  it 'returns a hash of all the accessorized properties' do
+    anon_class = Class.new do
+      include FormatParser::AttributesJSON
+      attr_accessor :foo, :bar, :baz
+      def nature
+        'good'
+      end
+    end
+    instance = anon_class.new
+    instance.foo = 42
+    instance.bar = 'abcdef'
+    expect(instance.as_json).to eq('nature' => 'good', 'foo' => 42, 'bar' => 'abcdef', 'baz' => nil)
+    expect(instance.as_json(root: true)).to eq('nature' => 'good', 'foo' => 42, 'bar' => 'abcdef', 'baz' => nil)
+  end
+
+  it 'is included into file information types' do
+    [
+      FormatParser::Image,
+      FormatParser::Video,
+      FormatParser::Audio,
+      FormatParser::Document
+    ].each do |file_related_class|
+      expect(file_related_class.ancestors).to include(FormatParser::AttributesJSON)
+    end
+  end
+end


### PR DESCRIPTION
for all the supported file types, based on accessor enumeration.

Closes #40 