### PR TITLE
Implement a sane to_json as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,11 @@ You can also optimize the metadata extraction by providing hints to the gem:
 FormatParser.parse(File.open("myimage", "rb"), natures: [:video, :image], formats: [:jpg, :png, :mp4], results: :all)
 ```
 
-If you need format_parser to return JSON, you can use `.as_json` to achieve this:
+Return values of all parsers have built-in JSON serialization
 
 ```ruby
-class Foo
-  include AttributesJSON
-  attr_accessor :number_of_bars
-end
-
-the_foo = Foo.new
-the_foo.number_of_bars = 42
-the_foo.as_json #=> {:number_of_bars => 42}
+img_info = FormatParser.parse(File.open("myimage.jpg", "rb"))
+JSON.pretty_generate(img_info) #=> ...
 ```
 
 ## Creating your own parsers

--- a/lib/attributes_json.rb
+++ b/lib/attributes_json.rb
@@ -25,4 +25,10 @@ module FormatParser::AttributesJSON
       h[reader_method_name] = value.respond_to?(:as_json) ? value.as_json : value
     end
   end
+
+  # Implements to_json with sane defaults - like
+  # support for `JSON.pretty_generate` vs. `JSON.dump`
+  def to_json(generator_state)
+    generator_state.generate(as_json)
+  end
 end

--- a/spec/attributes_json_spec.rb
+++ b/spec/attributes_json_spec.rb
@@ -26,4 +26,27 @@ describe FormatParser::AttributesJSON do
       expect(file_related_class.ancestors).to include(FormatParser::AttributesJSON)
     end
   end
+
+  it 'provides a default implementation of to_json as well' do
+    anon_class = Class.new do
+      include FormatParser::AttributesJSON
+      attr_accessor :foo, :bar, :baz
+      def nature
+        'good'
+      end
+    end
+    instance = anon_class.new
+    instance.foo = 42
+    instance.bar = 'abcdef'
+
+    output = JSON.dump(instance)
+    readback = JSON.parse(output, symbolize_names: true)
+
+    expect(readback).to have_key(:nature)
+
+    # Make sure we support pretty_generate correctly
+    pretty_output = JSON.pretty_generate(instance)
+    standard_output = JSON.dump(instance)
+    expect(pretty_output).not_to eq(standard_output)
+  end
 end


### PR DESCRIPTION
since it comes for free only within Rails.
I also removed the JSON section from the README
since the features we provide are about file format
detection, not about JSON-ing arbitrary objects