### PR TITLE
Pagefault limit

### DIFF
--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'wetransfer_style', '0.4.0'
+  spec.add_development_dependency 'wetransfer_style', '0.5.0'
 end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -45,4 +45,10 @@ class FormatParser::ReadLimiter
 
     @io.read(n)
   end
+
+  def reset_limits!
+    @seeks = 0
+    @reads = 0
+    @bytes = 0
+  end
 end

--- a/spec/read_limiter_spec.rb
+++ b/spec/read_limiter_spec.rb
@@ -41,4 +41,14 @@ describe FormatParser::ReadLimiter do
       reader.read(1)
     }.to raise_error(/bytes budget \(512\) exceeded/)
   end
+
+  it 'can be reset!' do
+    reader = FormatParser::ReadLimiter.new(io, max_bytes: 512)
+    reader.read(512)
+    expect {
+      reader.read(1)
+    }.to raise_error(/budget/)
+    reader.reset_limits!
+    reader.read(1)
+  end
 end


### PR DESCRIPTION
Forbid parsers to cause more than N page faults, which when using RemoteIO will turn into more and more HTTP requests.

Also remove the initial read() for remote data since we would have to perform it anyway

Closes #41