### PR TITLE
Add seek modes required by exifr

### DIFF
--- a/lib/io_constraint.rb
+++ b/lib/io_constraint.rb
@@ -1,4 +1,3 @@
-
 # We deliberately want to document and restrict the
 # number of methods an IO-ish object has to implement
 # to be usable with all our parsers. This subset is fairly

--- a/lib/parsers/exif_parser.rb
+++ b/lib/parsers/exif_parser.rb
@@ -5,12 +5,26 @@ require 'delegate'
 class FormatParser::EXIFParser
   include FormatParser::IOUtils
 
-  # EXIFR kindly requests the presence of getbyte and readbyte
-  # IO methods, which our constrained IO subset does not provide natively
+  # EXIFR kindly requests the presence of a few more methods than what our IOConstraint
+  # is willing to provide, but they can be derived from the available ones
   class IOExt < SimpleDelegator
     def readbyte
       if byte = read(1)
         byte.unpack('C').first
+      end
+    end
+
+    def seek(n, seek_mode = IO::SEEK_SET)
+      io = __getobj__
+      case seek_mode
+      when IO::SEEK_SET
+        io.seek(n)
+      when IO::SEEK_CUR
+        io.seek(io.pos + n)
+      when IO::SEEK_END
+        io.seek(io.size + n)
+      else
+        raise Errno::EINVAL
       end
     end
 

--- a/spec/parsers/exif_parser_spec.rb
+++ b/spec/parsers/exif_parser_spec.rb
@@ -30,4 +30,30 @@ describe FormatParser::EXIFParser do
       end
     end
   end
+
+  describe 'IOExt' do
+    it 'supports readbyte' do
+      io = FormatParser::EXIFParser::IOExt.new(StringIO.new('hello'))
+      expect(io.readbyte).to eq(104)
+    end
+
+    it 'supports getbyte' do
+      io = FormatParser::EXIFParser::IOExt.new(StringIO.new('hello'))
+      expect(io.getbyte).to eq(104)
+    end
+
+    it 'supports seek modes' do
+      io = FormatParser::EXIFParser::IOExt.new(StringIO.new('hello'))
+      io.seek(1, IO::SEEK_SET)
+
+      io.seek(1, IO::SEEK_CUR)
+      expect(io.read(1)).to eq('l')
+
+      io.seek(-1, IO::SEEK_END)
+      expect(io.read(1)).to eq('o')
+
+      io.seek(1)
+      expect(io.read(1)).to eq('e')
+    end
+  end
 end


### PR DESCRIPTION
since in certain situations exifr can apparently do a seek() with 2 arguments

ArgumentError::wrong number of arguments (given 2, expected 1)

```
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/format_parser-0.3.3/lib/io_constraint.rb:27:in `seek'
/usr/lib/ruby/2.4.0/delegate.rb:83:in `method_missing'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/exifr-1.3.3/lib/exifr/tiff.rb:668:in `size'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/exifr-1.3.3/lib/exifr/tiff.rb:518:in `next?'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/exifr-1.3.3/lib/exifr/tiff.rb:522:in `next'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/exifr-1.3.3/lib/exifr/tiff.rb:378:in `block in initialize'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/exifr-1.3.3/lib/exifr/tiff.rb:642:in `open'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/exifr-1.3.3/lib/exifr/tiff.rb:376:in `initialize'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/format_parser-0.3.3/lib/parsers/exif_parser.rb:52:in `new'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/format_parser-0.3.3/lib/parsers/exif_parser.rb:52:in `scan_image_exif'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/format_parser-0.3.3/lib/parsers/tiff_parser.rb:17:in `call'
/home/<redacted>/vendor/bundle/ruby/2.4.0/gems/format_parser-0.3.3/lib/format_parser.rb:90:in `block in parse'
```

Closes #73 