### PR TITLE
Make sure root: and to_json without arguments work

### DIFF
--- a/lib/attributes_json.rb
+++ b/lib/attributes_json.rb
@@ -14,7 +14,7 @@ module FormatParser::AttributesJSON
 
   # Implements a sane default `as_json` for an object
   # that accessors defined
-  def as_json(*_maybe_root_option)
+  def as_json(root: false)
     h = {}
     h['nature'] = nature if respond_to?(:nature) # Needed for file info structs
     methods.grep(/\w\=$/).each_with_object(h) do |attr_writer_method_name, h|
@@ -24,11 +24,15 @@ module FormatParser::AttributesJSON
       # by the caller
       h[reader_method_name] = value.respond_to?(:as_json) ? value.as_json : value
     end
+    if root
+      {'format_parser_file_info' => h}
+    else
+      h
+    end
   end
 
-  # Implements to_json with sane defaults - like
-  # support for `JSON.pretty_generate` vs. `JSON.dump`
-  def to_json(generator_state)
-    generator_state.generate(as_json)
+  # Implements to_json with sane defaults, with or without arguments
+  def to_json(*maybe_generator_state)
+    as_json(root: false).to_json(*maybe_generator_state)
   end
 end

--- a/spec/attributes_json_spec.rb
+++ b/spec/attributes_json_spec.rb
@@ -13,7 +13,7 @@ describe FormatParser::AttributesJSON do
     instance.foo = 42
     instance.bar = 'abcdef'
     expect(instance.as_json).to eq('nature' => 'good', 'foo' => 42, 'bar' => 'abcdef', 'baz' => nil)
-    expect(instance.as_json(root: true)).to eq('nature' => 'good', 'foo' => 42, 'bar' => 'abcdef', 'baz' => nil)
+    expect(instance.as_json(root: true)).to eq('format_parser_file_info' => {'nature' => 'good', 'foo' => 42, 'bar' => 'abcdef', 'baz' => nil})
   end
 
   it 'is included into file information types' do
@@ -48,5 +48,23 @@ describe FormatParser::AttributesJSON do
     pretty_output = JSON.pretty_generate(instance)
     standard_output = JSON.dump(instance)
     expect(pretty_output).not_to eq(standard_output)
+  end
+
+  it 'provides to_json without arguments' do
+    anon_class = Class.new do
+      include FormatParser::AttributesJSON
+      attr_accessor :foo, :bar, :baz
+      def nature
+        'good'
+      end
+    end
+    instance = anon_class.new
+    instance.foo = 42
+    instance.bar = 'abcdef'
+
+    output = instance.to_json
+    readback = JSON.parse(output, symbolize_names: true)
+
+    expect(readback).to have_key(:nature)
   end
 end


### PR DESCRIPTION
It is possible to call to_json without passing
a generator object, which only gets passed if
the to_json is called by JSON.dump/JSON.pretty_generate

Also implements sane support for the root option as
per the ActiveModel::Serializers convention