### PR TITLE
Optimize EOCD signature lookup

### DIFF
--- a/lib/parsers/zip_parser/file_reader.rb
+++ b/lib/parsers/zip_parser/file_reader.rb
@@ -344,38 +344,35 @@ class FormatParser::ZIPParser::FileReader
     eocd_offset
   end
 
-  # This is tricky. Essentially, we have to scan the maximum possible number
-  # of bytes (that the EOCD can theoretically occupy including the comment),
-  # and we have to find a combination of:
-  #   [EOCD signature, <some ZIP medatata>, comment byte size, the comment of
-  # that size, eof].
-  # The only way I could find to do this was with a sliding window, but
-  # there probably is a better way.
+  def all_indices_of_substr_in_str(of_substring, in_string)
+    last_i = 0
+    found_at_indices = []
+    while last_i = in_string.index(of_substring, last_i)
+      found_at_indices << last_i
+      last_i = last_i + of_substring.bytesize
+    end
+    found_at_indices
+  end
+
   def locate_eocd_signature(in_str)
-    # We have to scan from the _very_ tail. We read the very minimum size
-    # the EOCD record can have (up to and including the comment size), using
-    # a sliding window. Once our end offset matches the comment size we found our
-    # EOCD marker.
+    eocd_signature = [0x06054b50].pack('V')
     unpack_pattern = 'VvvvvVVv'
     minimum_record_size = 22
-    end_location = minimum_record_size * -1
-    loop do
-      # If the window is nil, we have rolled off the start of the string, nothing to do here.
-      # We use negative values because if we used positive slice indices
-      # we would have to detect the rollover ourselves
-      break unless window = in_str[end_location, minimum_record_size]
-      window_location = in_str.bytesize + end_location
-      unpacked = window.unpack(unpack_pattern)
-      # If we found the signarue, pick up the comment size, and check if the size of the window
-      # plus that comment size is where we are in the string. If we are - bingo.
-      if unpacked[0] == 0x06054b50 && comment_size = unpacked[-1]
-        assumed_eocd_location = in_str.bytesize - comment_size - minimum_record_size
-        # if the comment size is where we should be at - we found our EOCD
-        return assumed_eocd_location if assumed_eocd_location == window_location
-      end
+    str_size = in_str.bytesize
+    indices = all_indices_of_substr_in_str(eocd_signature, in_str)
+    indices.each do |check_at|
+      maybe_record = in_str[check_at..str_size]
+      # If the record is smaller than the minimum - we will never recover anything
+      return if maybe_record.bytesize < minimum_record_size
+      signature, *_rest, comment_size = maybe_record.unpack(unpack_pattern)
 
-      end_location -= 1 # Shift the window back, by one byte, and try again.
+      # Check the only condition for the match
+      if signature == 0x06054b50 && (maybe_record.bytesize - minimum_record_size) == comment_size
+        return check_at # Found the EOCD marker location
+      end
     end
+    # If we haven't caught anything, return nil deliberately instead of returning the last statement
+    nil
   end
 
   # Find the Zip64 EOCD locator segment offset. Do this by seeking backwards from the

--- a/lib/parsers/zip_parser/file_reader.rb
+++ b/lib/parsers/zip_parser/file_reader.rb
@@ -349,7 +349,7 @@ class FormatParser::ZIPParser::FileReader
     found_at_indices = []
     while last_i = in_string.index(of_substring, last_i)
       found_at_indices << last_i
-      last_i = last_i + of_substring.bytesize
+      last_i += of_substring.bytesize
     end
     found_at_indices
   end
@@ -363,7 +363,7 @@ class FormatParser::ZIPParser::FileReader
     indices.each do |check_at|
       maybe_record = in_str[check_at..str_size]
       # If the record is smaller than the minimum - we will never recover anything
-      return if maybe_record.bytesize < minimum_record_size
+      break if maybe_record.bytesize < minimum_record_size
       signature, *_rest, comment_size = maybe_record.unpack(unpack_pattern)
 
       # Check the only condition for the match

--- a/spec/parsers/zip_parser_spec.rb
+++ b/spec/parsers/zip_parser_spec.rb
@@ -64,7 +64,7 @@ describe FormatParser::ZIPParser do
 
   it 'is able to handle specific fuzzed input' do
     r = Random.new(354)
-    1024.times do |n|
+    1024.times do
       random_blob = StringIO.new(r.bytes(512 * 1024))
       subject.call(random_blob) # If there is an error in one of the parsers the example will raise too
     end

--- a/spec/parsers/zip_parser_spec.rb
+++ b/spec/parsers/zip_parser_spec.rb
@@ -62,6 +62,14 @@ describe FormatParser::ZIPParser do
     expect(result.format).to eq(:docx)
   end
 
+  it 'is able to handle specific fuzzed input' do
+    r = Random.new(354)
+    1024.times do |n|
+      random_blob = StringIO.new(r.bytes(512 * 1024))
+      subject.call(random_blob) # If there is an error in one of the parsers the example will raise too
+    end
+  end
+
   it 'returns a result that has a usable JSON representation' do
     fixture_path = fixtures_dir + '/ZIP/arch_with_empty_dir.zip'
     fi_io = File.open(fixture_path, 'rb')


### PR DESCRIPTION
Instead of using a rolling window that gets shifted by a byte on each iteration, first find all the instances of the EOCD marker in the string under test and then check these locations only for the pattern of "signature + padding + comment_size + comment".

This allows the lookup to also terminate much faster if the signature cannot be found in the file segment at all.