### PR TITLE
Raise the cache page size during detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Unless specified otherwise in this section the fixture files are MIT licensed an
 
 ### JPEG
 - `divergent_pixel_dimensions_exif.jpg` is used with permission from LiveKom GmbH
+- `extended_reads.jpg` has kindly been made available by Raphaelle Pellerin for use exclusively with format_parser
 
 ### AIFF
 - fixture.aiff was created by one of the project maintainers and is MIT licensed

--- a/lib/care.rb
+++ b/lib/care.rb
@@ -4,7 +4,7 @@
 # is only available via HTTP, for example, we can have less
 # fetches and have them return more data for one fetch
 class Care
-  DEFAULT_PAGE_SIZE = 16 * 1024
+  DEFAULT_PAGE_SIZE = 64 * 1024
 
   class IOWrapper
     def initialize(io, cache = Cache.new(DEFAULT_PAGE_SIZE))

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
We are failing detection on a number of JPEGs because the file dimensions in them are further away from the beginning of the file, and with 16KB pages we would fail reading them. Given that the biggest overhead is not the _amount_ of data that we fetch but the _number_ of requests we do, it makes sense to bump the size of the cache page - and increase memory use slightly - to allow more files to be correctly parsed before the limiters kick in.