### PR TITLE
Start on YARD documentation

### DIFF
--- a/lib/care.rb
+++ b/lib/care.rb
@@ -4,27 +4,50 @@
 # is only available via HTTP, for example, we can have less
 # fetches and have them return more data for one fetch
 class Care
+  # Defines the size of a page in bytes that the Care will prefetch
   DEFAULT_PAGE_SIZE = 128 * 1024
 
+  # Wraps any given IO with Care caching superpowers. Supports the subset
+  # of IO declared in IOConstraint.
   class IOWrapper
+
+    # Creates a new IOWrapper around the given source IO
+    #
+    # @param io[#seek, #pos, #size] the IO to wrap
+    # @param page_size[Integer] the size of the cache page to use for this wrapper
     def initialize(io, page_size: DEFAULT_PAGE_SIZE)
       @cache = Cache.new(page_size)
       @io = io
       @pos = 0
     end
 
+    # Returns the size of the resource contained in the IO
+    #
+    # @return Integer
     def size
       @io.size
     end
 
+    # Seeks the IO to the given absolute offset from the start of the file/resource
+    #
+    # @param to[Integer] offset in the IO
+    # @return Integer
     def seek(to)
       @pos = to
     end
 
+    # Returns the current position/offset within the IO
+    #
+    # @return Integer
     def pos
       @pos
     end
 
+    # Returns at most `n_bytes` of data from the IO or less if less data was available
+    # before the EOF was hit
+    #
+    # @param n_bytes[Integer]
+    # @return [String, nil] the content read from the IO or `nil` if no data was available
     def read(n_bytes)
       return '' if n_bytes == 0 # As hardcoded for all Ruby IO objects
       raise ArgumentError, "negative length #{n_bytes} given" if n_bytes < 0 # also as per Ruby IO objects
@@ -34,10 +57,17 @@ class Care
       read
     end
 
+    # Clears all the cached pages explicitly to help GC
+    #
+    # @return void
     def clear
       @cache.clear
     end
 
+    # Clears all the cached pages explicitly to help GC, and
+    # calls `#close` on the source IO if the IO responds to `#close`
+    #
+    # @return void
     def close
       clear
       @io.close if @io.respond_to?(:close)
@@ -47,6 +77,7 @@ class Care
   # Stores cached pages of data from the given IO as strings.
   # Pages are sized to be `page_size` or less (for the last page).
   class Cache
+    # Initializes a new cache pages container with pages of given size
     def initialize(page_size = DEFAULT_PAGE_SIZE)
       @page_size = page_size.to_i
       raise ArgumentError, 'The page size must be a positive Integer' unless @page_size > 0
@@ -59,6 +90,12 @@ class Care
     # If the IO has been exhausted, `nil` will be returned
     # instead. Will use the cached pages where available,
     # or fetch pages where necessary
+    #
+    # @param io[#seek, #read] the IO to read data from
+    # @param at[Integer] at which offset we have to read
+    # @param n_bytes[Integer] how many bytes we want to read/cache
+    # @return [String, nil] the content read from the IO or `nil` if no data was available
+    # @raise ArgumentError
     def byteslice(io, at, n_bytes)
       if n_bytes < 1
         raise ArgumentError, "The number of bytes to fetch must be a positive Integer, but was #{n_bytes}"
@@ -97,10 +134,18 @@ class Care
       slice if slice && !slice.empty?
     end
 
+    # Clears the page cache of all strings with data
+    #
+    # @return void
     def clear
       @pages.clear
     end
 
+    # Hydrates a page at the certain index or returns the contents of
+    # that page if it is already in the cache
+    #
+    # @param io[IO] the IO to read from
+    # @param page_i[Integer] which page (zero-based) to hydrate and return
     def hydrate_page(io, page_i)
       # Avoid trying to read the page if we know there is no content to fill it
       # in the underlying IO
@@ -109,8 +154,9 @@ class Care
       @pages[page_i] ||= read_page(io, page_i)
     end
 
+    # We provide an overridden implementation of #inspect to avoid
+    # printing the actual contents of the cached pages
     def inspect
-      # To avoid page _contents_ in the inspect outputs we need to implement our own inspect.
 
       # Simulate the builtin object ID output https://stackoverflow.com/a/11765495/153886
       oid_str = (object_id << 1).to_s(16).rjust(16, '0')
@@ -124,6 +170,10 @@ class Care
       '#<%s:%s %s %s>' % [self.class, oid_str, synthetic_vars, ivars_str]
     end
 
+    # Reads the requested page from the given IO
+    #
+    # @param io[IO] the IO to read from
+    # @param page_i[Integer] which page (zero-based) to read
     def read_page(io, page_i)
       io.seek(page_i * @page_size)
       read_result = io.read(@page_size)

--- a/lib/care.rb
+++ b/lib/care.rb
@@ -10,7 +10,6 @@ class Care
   # Wraps any given IO with Care caching superpowers. Supports the subset
   # of IO declared in IOConstraint.
   class IOWrapper
-
     # Creates a new IOWrapper around the given source IO
     #
     # @param io[#seek, #pos, #size] the IO to wrap
@@ -157,7 +156,6 @@ class Care
     # We provide an overridden implementation of #inspect to avoid
     # printing the actual contents of the cached pages
     def inspect
-
       # Simulate the builtin object ID output https://stackoverflow.com/a/11765495/153886
       oid_str = (object_id << 1).to_s(16).rjust(16, '0')
 

--- a/lib/io_constraint.rb
+++ b/lib/io_constraint.rb
@@ -19,18 +19,33 @@ class FormatParser::IOConstraint
     @io = io
   end
 
+  # Returns at most `n_bytes` of data from the IO or less if less data was available
+  # before the EOF was hit
+  #
+  # @param n_bytes[Integer]
+  # @return [String, nil] the content read from the IO or `nil` if no data was available
   def read(n_bytes)
     @io.read(n_bytes)
   end
 
-  def seek(absolute_offset)
-    @io.seek(absolute_offset)
+  # Seeks the IO to the given absolute offset from the start of the file/resource
+  #
+  # @param to[Integer] offset in the IO
+  # @return Integer
+  def seek(to)
+    @io.seek(to)
   end
 
+  # Returns the size of the resource contained in the IO
+  #
+  # @return Integer
   def size
     @io.size
   end
 
+  # Returns the current position/offset within the IO
+  #
+  # @return Integer
   def pos
     @io.pos
   end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -1,9 +1,17 @@
+# Is used to limit the number of reads/seeks parsers can perform
 class FormatParser::ReadLimiter
   NO_LIMIT = nil
 
   class BudgetExceeded < StandardError
   end
 
+  # Creates a ReadLimiter wrapper around the given IO object and sets the limits
+  # on the number of reads/writes
+  #
+  # @param io[#seek, #pos, #size, #read] the IO object to wrap
+  # @param max_bytes[Integer, nil] how many bytes can we read from this before an exception is raised
+  # @param max_reads[Integer, nil] how many read() calls can we perform on this before an exception is raised
+  # @param max_seeks[Integer, nil] how many seek() calls can we perform on this before an exception is raised
   def initialize(io, max_bytes: NO_LIMIT, max_reads: NO_LIMIT, max_seeks: NO_LIMIT)
     @max_bytes = max_bytes
     @max_reads = max_reads
@@ -15,24 +23,39 @@ class FormatParser::ReadLimiter
     @bytes = 0
   end
 
+  # Returns the size of the resource contained in the IO
+  #
+  # @return Integer
   def size
     @io.size
   end
 
+  # Returns the current position/offset within the IO
+  #
+  # @return Integer
   def pos
     @io.pos
   end
 
-  def seek(to_offset)
+  # Seeks the IO to the given absolute offset from the start of the file/resource
+  #
+  # @param to[Integer] offset in the IO
+  # @return Integer
+  def seek(to)
     @seeks += 1
     if @max_seeks && @seeks > @max_seeks
       raise BudgetExceeded, 'Seek budget exceeded (%d seeks performed)' % @max_seeks
     end
-    @io.seek(to_offset)
+    @io.seek(to)
   end
 
-  def read(n)
-    @bytes += n
+  # Returns at most `n_bytes` of data from the IO or less if less data was available
+  # before the EOF was hit
+  #
+  # @param n_bytes[Integer]
+  # @return [String, nil] the content read from the IO or `nil` if no data was available
+  def read(n_bytes)
+    @bytes += n_bytes
     @reads += 1
 
     if @max_bytes && @bytes > @max_bytes
@@ -43,9 +66,12 @@ class FormatParser::ReadLimiter
       raise BudgetExceeded, 'Number of read() calls exceeded (%d max)' % @max_reads
     end
 
-    @io.read(n)
+    @io.read(n_bytes)
   end
 
+  # Resets all the recorded call counters so that the object can be reused for the next parser,
+  # which will have it's own limits
+  # @return void
   def reset_limits!
     @seeks = 0
     @reads = 0

--- a/lib/read_limits_config.rb
+++ b/lib/read_limits_config.rb
@@ -5,23 +5,50 @@ class FormatParser::ReadLimitsConfig
     @max_read_bytes_per_parser = total_bytes_available_per_parser.to_i
   end
 
+
+  # Defines how many bytes each parser may request to read from the IO object given to it.
+  # Is used to artificially limit unbounded reads in parsers that may wander off and
+  # try to gulp in the file given to them indefinitely due to infinite loops or
+  # wrongly implemented skips - or when handling data that has been deliberately
+  # crafted in a way that can make a parser misbehave.
+  # This is less strict than one could think - for example, the MOOV parser used for
+  # Quicktime files will skip over the actual atom contents of the atoms, and will only
+  # read atom headers - which stays under this limit for quite some time.
   def max_read_bytes_per_parser
     @max_read_bytes_per_parser
   end
 
+  # How big should the cache page be. Each cache page read will incur one `#read`
+  # on the underlying IO object, remote or local
   def cache_page_size
     @max_read_bytes_per_parser / 4
   end
 
+  # Each parser can incur HTTP requests when performing `parse_http`. This constant
+  # sets the maximum number of pages each parser is allowed to hit that have not
+  # been fetched previously and are not stored in the cache. For example, with most
+  # formats the first cache page and the last cache page - tail and head of the file,
+  # respectively - will be available right after the first parser retreives some data.
+  # The second parser accessing the same data will reuse the in-memory cache.
   def max_pagefaults_per_parser
     MAX_PAGE_FAULTS
   end
 
+  # Defines how many `#read` calls each parser may perform on the IO object given to it.
+  # Is used to artificially limit unbounded reads in parsers that may wander off and
+  # try to gulp in the file given to them indefinitely due to infinite loops or
+  # wrongly implemented skips - or when handling data that has been deliberately
+  # crafted in a way that can make a parser misbehave.
   def max_reads_per_parser
     # Imagine we read per single byte
     @max_read_bytes_per_parser / 2
   end
 
+  # Defines how many `#seek` calls each parser may perform on the IO object given to it.
+  # Is used to artificially limit unbounded reads in parsers that may wander off and
+  # try to gulp in the file given to them indefinitely due to infinite loops or
+  # wrongly implemented skips - or when handling data that has been deliberately
+  # crafted in a way that can make a parser misbehave.
   def max_seeks_per_parser
     # Imagine we have to seek once per byte
     @max_read_bytes_per_parser / 2

--- a/lib/read_limits_config.rb
+++ b/lib/read_limits_config.rb
@@ -5,7 +5,6 @@ class FormatParser::ReadLimitsConfig
     @max_read_bytes_per_parser = total_bytes_available_per_parser.to_i
   end
 
-
   # Defines how many bytes each parser may request to read from the IO object given to it.
   # Is used to artificially limit unbounded reads in parsers that may wander off and
   # try to gulp in the file given to them indefinitely due to infinite loops or

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -1,3 +1,8 @@
+# Acts as a wrapper for turning a given URL into an IO object
+# you can read from and seek in. Uses Faraday under the hood
+# to perform fetches, so if you apply Faraday configuration
+# tweaks using `Faraday.default_connection = ...` these will
+# take effect for these RemoteIO objects as well
 class FormatParser::RemoteIO
   # Represents a failure that might be retried
   # (like a 5xx response or a timeout)


### PR DESCRIPTION
We want this to be usable without reading the source code, so why not put some yardsticks in the ground?

This documents a number of public APIs, not all of them - but it's a start.