### PR TITLE
Double the cache page size once more

### DIFF
--- a/lib/care.rb
+++ b/lib/care.rb
@@ -4,7 +4,7 @@
 # is only available via HTTP, for example, we can have less
 # fetches and have them return more data for one fetch
 class Care
-  DEFAULT_PAGE_SIZE = 64 * 1024
+  DEFAULT_PAGE_SIZE = 128 * 1024
 
   class IOWrapper
     def initialize(io, cache = Cache.new(DEFAULT_PAGE_SIZE))


### PR DESCRIPTION
so that we can accommodate more JPEGs. Specifically in combination with #98 this should fix even more cases - the issue we saw with the wallpapers was due to the files blowing _both_ the page fault limiter _and_ the number-of-reads limiter, because EXIFR was so thorough.