### PR TITLE
Add instrumentation

### DIFF
--- a/lib/care.rb
+++ b/lib/care.rb
@@ -173,9 +173,10 @@ class Care
     # @param io[IO] the IO to read from
     # @param page_i[Integer] which page (zero-based) to read
     def read_page(io, page_i)
+      FormatParser::Measurometer.increment_counter('format_parser.parser.Care.page_reads_from_upsteam', 1)
+
       io.seek(page_i * @page_size)
       read_result = io.read(@page_size)
-
       if read_result.nil?
         # If the read went past the end of the IO the read result will be nil,
         # so we know our IO is exhausted here

--- a/lib/io_utils.rb
+++ b/lib/io_utils.rb
@@ -26,11 +26,7 @@ module FormatParser::IOUtils
 
     raise InvalidRead, 'Negative skips are not supported' if n < 0
 
-    if io.respond_to?(:pos)
-      io.seek(io.pos + n)
-    else
-      safe_read(io, n)
-    end
+    io.seek(io.pos + n)
     nil
   end
 

--- a/lib/measurometer.rb
+++ b/lib/measurometer.rb
@@ -6,11 +6,40 @@ class FormatParser::Measurometer
     # as a driver.
     #
     #   Measurometer.drivers << Appsignal
+    #
+    # A driver must be reentrant and thread-safe - it should be possible
+    # to have multiple `instrument` calls open from different threads at the
+    # same time.
+    # The driver must support the same interface as the Measurometer class
+    # itself, minus the `drivers` and `instrument_instance_method` methods.
+    #
+    # @return Array
     def drivers
       @drivers ||= []
       @drivers
     end
 
+    # Runs a given block within a cascade of `instrument` blocks of all the
+    # added drivers.
+    #
+    #   Measurometer.instrument('do_foo') { compute! }
+    #
+    # unfolds to
+    #   Appsignal.instrument('do_foo') do
+    #     Statsd.timing('do_foo') do
+    #       compute!
+    #     end
+    #   end
+    #
+    # A driver must be reentrant and thread-safe - it should be possible
+    # to have multiple `instrument` calls open from different threads at the
+    # same time.
+    # The driver must support the same interface as the Measurometer class
+    # itself, minus the `drivers` and `instrument_instance_method` methods.
+    #
+    # @param block_name[String] under which path to push the metric
+    # @param blk[#call] the block to instrument
+    # @return [Object] the return value of &blk
     def instrument(block_name, &blk)
       return yield unless @drivers && @drivers.any? # The block wrapping business is not free
       @drivers.inject(blk) { |outer_block, driver|
@@ -20,21 +49,40 @@ class FormatParser::Measurometer
       }.call
     end
 
+    # Adds a distribution value (sample) under a given path
+    #
+    # @param value_path[String] under which path to push the metric
+    # @param value[Numeric] distribution value
+    # @return nil
     def add_distribution_value(value_path, value)
       (@drivers || []).each { |d| d.add_distribution_value(value_path, value) }
       nil
     end
 
+    # Increment a named counter under a given path
+    #
+    # @param counter_path[String] under which path to push the metric
+    # @param by[Integer] the counter increment to apply
+    # @return nil
     def increment_counter(counter_path, by)
       (@drivers || []).each { |d| d.increment_counter(counter_path, by) }
       nil
     end
 
-    def instrument_instance_method(target_class, method_to_instrument, path_prefix)
+    # Wrap an anonymous module around an instance method in the given class to have
+    # it instrumented automatically. The name of the measurement will be interpolated as:
+    #
+    #   "#{prefix}.#{rightmost_class_constant_name}.#{instance_method_name}"
+    #
+    # @param target_class[Class] the class to instrument
+    # @param instance_method_name_to_instrument[Symbol] the method name to instrument
+    # @param path_prefix[String] under which path to push the instrumented metric
+    # @return void
+    def instrument_instance_method(target_class, instance_method_name_to_instrument, path_prefix)
       short_class_name = target_class.to_s.split('::').last
-      instrumentation_name = [path_prefix, short_class_name, method_to_instrument].join('.')
+      instrumentation_name = [path_prefix, short_class_name, instance_method_name_to_instrument].join('.')
       instrumenter_module = Module.new do
-        define_method(method_to_instrument) do |*any|
+        define_method(instance_method_name_to_instrument) do |*any|
           ::FormatParser::Measurometer.instrument(instrumentation_name) { super(*any) }
         end
       end

--- a/lib/measurometer.rb
+++ b/lib/measurometer.rb
@@ -1,0 +1,52 @@
+class FormatParser::Measurometer
+  class << self
+    # Permits adding instrumentation drivers. Measurometer is 1-1 API
+    # compatible with Appsignal, which we use a lot. So to magically
+    # obtain all Appsignal instrumentation, add the Appsignal module
+    # as a driver.
+    #
+    #   Measurometer.drivers << Appsignal
+    def drivers
+      @drivers ||= []
+      @drivers
+    end
+
+    def instrument(block_name, &blk)
+      return yield unless @drivers && @drivers.any? # The block wrapping business is not free
+      @drivers.inject(blk) { |outer_block, driver|
+        -> {
+          driver.instrument(block_name, &outer_block)
+        }
+      }.call
+    end
+
+    def add_distribution_value(value_path, value)
+      (@drivers || []).each { |d| d.add_distribution_value(value_path, value) }
+      nil
+    end
+
+    def increment_counter(counter_path, by)
+      (@drivers || []).each { |d| d.increment_counter(counter_path, by) }
+      nil
+    end
+
+    def instrument_instance_method(target_class, method_to_instrument, path_prefix)
+      short_class_name = target_class.to_s.split('::').last
+      instrumentation_name = [path_prefix, short_class_name, method_to_instrument].join('.')
+      instrumenter_module = Module.new do
+        define_method(method_to_instrument) do |*any|
+          ::FormatParser::Measurometer.instrument(instrumentation_name) { super(*any) }
+        end
+      end
+      target_class.prepend(instrumenter_module)
+    end
+  end
+
+  # Instrument things interesting in the global sense
+  instrument_instance_method(FormatParser::RemoteIO, :read, 'format_parser')
+  instrument_instance_method(Care::Cache, :read_page, 'format_parser')
+
+  # Instrument more specific things on a per-parser basis
+  instrument_instance_method(FormatParser::EXIFParser, :scan_image_tiff, 'format_parser')
+  instrument_instance_method(FormatParser::MOOVParser::Decoder, :extract_atom_stream, 'format_parser.parsers.MOOVParser')
+end

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -112,6 +112,7 @@ class FormatParser::JPEGParser
     maybe_exif_magic_str = app1_frame_bytes[0..5]
     maybe_exif_data = app1_frame_bytes[6..-1]
     if maybe_exif_magic_str == EXIF_MAGIC_STRING
+      FormatParser::Measurometer.add_distribution_value('format_parser.JPEGParser.bytes_sent_to_exif_parser', maybe_exif_data.bytesize)
       scanner = FormatParser::EXIFParser.new(StringIO.new(maybe_exif_data))
       scanner.scan_image_tiff
 

--- a/lib/parsers/moov_parser.rb
+++ b/lib/parsers/moov_parser.rb
@@ -11,10 +11,6 @@ class FormatParser::MOOVParser
     'm4a ' => :m4a,
   }
 
-  # It is currently not documented and not particularly well-tested,
-  # so not considered a public API for now
-  private_constant :Decoder
-
   def call(io)
     return unless matches_moov_definition?(io)
 

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -69,6 +69,17 @@ class FormatParser::ReadLimiter
     @io.read(n_bytes)
   end
 
+  # Sends the metrics about the state of this ReadLimiter to a Measurometer
+  #
+  # @param prefix[String] the prefix to set. For example, with prefix "TIFF" the metrics will be called
+  #   `format_parser.TIFF.read_limiter.num_seeks` and so forth
+  # @return void
+  def send_metrics(prefix)
+    FormatParser::Measurometer.add_distribution_value('format_parser.%s.read_limiter.num_seeks' % prefix, @seeks)
+    FormatParser::Measurometer.add_distribution_value('format_parser.%s.read_limiter.num_reads' % prefix, @reads)
+    FormatParser::Measurometer.add_distribution_value('format_parser.%s.read_limiter.read_bytes' % prefix, @bytes)
+  end
+
   # Resets all the recorded call counters so that the object can be reused for the next parser,
   # which will have it's own limits
   # @return void

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -94,8 +94,10 @@ class FormatParser::RemoteIO
       # cannot hint size with this response - at lease not when working with S3
       return
     when 500..599
+      FormatParser::Measurometer.increment_counter('format_parser.RemoteIO.upstream50x_errors', 1)
       raise IntermittentFailure, "Server at #{@uri} replied with a #{response.status} and we might want to retry"
     else
+      FormatParser::Measurometer.increment_counter('format_parser.RemoteIO.invalid_request_errors', 1)
       raise InvalidRequest, "Server at #{@uri} replied with a #{response.status} and refused our request"
     end
   end

--- a/spec/io_utils_spec.rb
+++ b/spec/io_utils_spec.rb
@@ -27,15 +27,9 @@ describe 'IOUtils' do
       }.to raise_error(FormatParser::IOUtils::InvalidRead)
     end
 
-    it 'uses #pos if available on the object' do
+    it 'uses #pos available on the object' do
       fake_io = double(pos: 11)
       expect(fake_io).to receive(:seek).with(11 + 5)
-      safe_skip(fake_io, 5)
-    end
-
-    it 'uses #read if no #pos is available on the object' do
-      fake_io = double
-      expect(fake_io).to receive(:read).with(5).and_return('x' * 5)
       safe_skip(fake_io, 5)
     end
   end

--- a/spec/measurometer_spec.rb
+++ b/spec/measurometer_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe FormatParser::Measurometer do
+  RSpec::Matchers.define :include_counter_or_measurement_named do |named|
+    match do |actual|
+      actual.any? do |e|
+        e[0] == named && e[1] > 0
+      end
+    end
+  end
+
+  it 'instruments a full cycle FormatParser.parse' do
+    driver_class = Class.new do
+      attr_accessor :timings, :counters, :distributions
+      def instrument(block_name)
+        s = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        yield.tap do
+          delta = Process.clock_gettime(Process::CLOCK_MONOTONIC) - s
+          @timings ||= []
+          @timings << [block_name, delta * 1000]
+        end
+      end
+
+      def add_distribution_value(value_path, value)
+        @distributions ||= []
+        @distributions << [value_path, value]
+      end
+
+      def increment_counter(value_path, value)
+        @counters ||= []
+        @counters << [value_path, value]
+      end
+    end
+
+    instrumenter = driver_class.new
+    described_class.drivers << instrumenter
+
+    FormatParser.parse(File.open(fixtures_dir + 'JPEG/keynote_recognized_as_jpeg.key', 'rb'), results: :all)
+
+    described_class.drivers.delete(instrumenter)
+    expect(described_class.drivers).not_to include(instrumenter)
+
+    expect(instrumenter.counters).to include_counter_or_measurement_named('format_parser.detected_formats.zip')
+    expect(instrumenter.counters).to include_counter_or_measurement_named('format_parser.parser.Care.page_reads_from_upsteam')
+    expect(instrumenter.distributions).to include_counter_or_measurement_named('format_parser.ZIPParser.read_limiter.read_bytes')
+    expect(instrumenter.timings).to include_counter_or_measurement_named('format_parser.Cache.read_page')
+  end
+end

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -27,11 +27,12 @@ describe 'Fetching data from HTTP remotes' do
   end
 
   it '#parse_http is called with hash options' do
-    expect_any_instance_of(FormatParser::AIFFParser).to receive(:call).and_return(:audio)
-    result = FormatParser.parse_http('http://localhost:9399/PNG/anim.png', results: :all)
+    fake_result = double(nature: :audio, format: :aiff)
+    expect_any_instance_of(FormatParser::AIFFParser).to receive(:call).and_return(fake_result)
+    results = FormatParser.parse_http('http://localhost:9399/PNG/anim.png', results: :all)
 
-    expect(result.include?(:audio)).to be true
-    expect(result.count).to eq(2)
+    expect(results.count).to eq(2)
+    expect(results).to include(fake_result)
   end
 
   it 'parses the animated PNG over HTTP' do


### PR DESCRIPTION
For ATC - but also for image_vise - it would be useful to see how many reads we perform, how many pagefaults, and how many HTTP requests we do, etcetera. We also should think about a generic way of adding multiplexed (sent to multiple destinations) instrumentation.

This PR adds an instrumentation device called `Measurometer` (we can extract it into a gem later if we desire) which can be hooked into Appsignal like so:

    FormatParser::Measurometer.drivers << Appsignal

Once you do, there will be delicious measurements and call graphs in Appsignal for everything format_parser related, as well as some counters and samples to look at. For example, how many files end up unrecognized? What is the distribution of file formats that we are getting? etc. 