### PR TITLE
Simplify BMP parser test

### DIFF
--- a/spec/parsers/bmp_parser_spec.rb
+++ b/spec/parsers/bmp_parser_spec.rb
@@ -1,49 +1,39 @@
 require 'spec_helper'
 
 describe FormatParser::BMPParser do
-  describe 'is able to parse BMP files' do
-    context 'with positive height_px values' do
-      it 'parses a BMP file' do
-        bmp_path = fixtures_dir + '/BMP/test.bmp'
-        parsed = subject.call(File.open(bmp_path, 'rb'))
+  it 'parses a BMP file with positive height_px values' do
+    bmp_path = fixtures_dir + '/BMP/test.bmp'
+    parsed = subject.call(File.open(bmp_path, 'rb'))
 
-        expect(parsed).not_to be_nil
-        expect(parsed.nature).to eq(:image)
-        expect(parsed.format).to eq(:bmp)
-        expect(parsed.color_mode).to eq(:rgb)
+    expect(parsed).not_to be_nil
+    expect(parsed.nature).to eq(:image)
+    expect(parsed.format).to eq(:bmp)
+    expect(parsed.color_mode).to eq(:rgb)
 
-        expect(parsed.width_px).to be_kind_of(Integer)
-        expect(parsed.width_px).to be > 0
-        expect(parsed.height_px).to be_kind_of(Integer)
-        expect(parsed.height_px).to be > 0
+    expect(parsed.width_px).to eq(40)
+    expect(parsed.height_px).to eq(27)
 
-        expect(parsed.intrinsics).not_to be_nil
-        expect(parsed.intrinsics[:vertical_resolution]).to be_kind_of(Integer)
-        expect(parsed.intrinsics[:horizontal_resolution]).to be_kind_of(Integer)
-        expect(parsed.intrinsics[:data_order]).to eq(:normal)
-      end
-    end
+    expect(parsed.intrinsics).not_to be_nil
+    expect(parsed.intrinsics[:vertical_resolution]).to be_kind_of(Integer)
+    expect(parsed.intrinsics[:horizontal_resolution]).to be_kind_of(Integer)
+    expect(parsed.intrinsics[:data_order]).to eq(:normal)
+  end
 
-    context 'with negative height_px values' do
-      it 'parses a BMP file' do
-        bmp_path = fixtures_dir + '/BMP/test2.bmp'
-        parsed = subject.call(File.open(bmp_path, 'rb'))
+  it 'parses a BMP file with negative height_px values (divergent scan order)' do
+    bmp_path = fixtures_dir + '/BMP/test2.bmp'
+    parsed = subject.call(File.open(bmp_path, 'rb'))
 
-        expect(parsed).not_to be_nil
-        expect(parsed.nature).to eq(:image)
-        expect(parsed.format).to eq(:bmp)
-        expect(parsed.color_mode).to eq(:rgb)
+    expect(parsed).not_to be_nil
+    expect(parsed.nature).to eq(:image)
+    expect(parsed.format).to eq(:bmp)
+    expect(parsed.color_mode).to eq(:rgb)
 
-        expect(parsed.width_px).to be_kind_of(Integer)
-        expect(parsed.width_px).to be > 0
-        expect(parsed.height_px).to be_kind_of(Integer)
-        expect(parsed.height_px).to be > 0
+    expect(parsed.width_px).to eq(1920)
+    expect(parsed.height_px).to eq(1080)
 
-        expect(parsed.intrinsics).not_to be_nil
-        expect(parsed.intrinsics[:vertical_resolution]).to be_kind_of(Integer)
-        expect(parsed.intrinsics[:horizontal_resolution]).to be_kind_of(Integer)
-        expect(parsed.intrinsics[:data_order]).to eq(:inverse)
-      end
-    end
+    expect(parsed.intrinsics).not_to be_nil
+    expect(parsed.intrinsics[:vertical_resolution]).to be_kind_of(Integer)
+    expect(parsed.intrinsics[:horizontal_resolution]).to be_kind_of(Integer)
+    expect(parsed.intrinsics[:data_order]).to eq(:inverse)
   end
 end

--- a/spec/parsers/bmp_parser_spec.rb
+++ b/spec/parsers/bmp_parser_spec.rb
@@ -14,8 +14,8 @@ describe FormatParser::BMPParser do
     expect(parsed.height_px).to eq(27)
 
     expect(parsed.intrinsics).not_to be_nil
-    expect(parsed.intrinsics[:vertical_resolution]).to be_kind_of(Integer)
-    expect(parsed.intrinsics[:horizontal_resolution]).to be_kind_of(Integer)
+    expect(parsed.intrinsics[:vertical_resolution]).to eq(2834)
+    expect(parsed.intrinsics[:horizontal_resolution]).to eq(2834)
     expect(parsed.intrinsics[:data_order]).to eq(:normal)
   end
 
@@ -32,8 +32,8 @@ describe FormatParser::BMPParser do
     expect(parsed.height_px).to eq(1080)
 
     expect(parsed.intrinsics).not_to be_nil
-    expect(parsed.intrinsics[:vertical_resolution]).to be_kind_of(Integer)
-    expect(parsed.intrinsics[:horizontal_resolution]).to be_kind_of(Integer)
+    expect(parsed.intrinsics[:vertical_resolution]).to eq(2835)
+    expect(parsed.intrinsics[:horizontal_resolution]).to eq(2835)
     expect(parsed.intrinsics[:data_order]).to eq(:inverse)
   end
 end


### PR DESCRIPTION
Reduce the number of nested contexts. Contexts are very useful
when there are multiple examples within them and when you need
common setup/teardown operations done for each example.

In this case, however, they create more indentation in
test formatters and also in code.

Also changes dimension assertions to checking actual values,
since we want to ensure the actual dimensions we got are correct.
For test2.bmp I could only assume the values are correct
since no application I got actually opens it. Should have used
GraphicConverter :-P