### PR TITLE
Move the section on parser writing to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,77 @@ or no result as soon as possible (once you know the file is not fit for your spe
 Bear in mind that we enforce read budgets per-parser, so you will not be allowed to perform
 too many reads, or perform reads which are too large.
 
+In order to create new parsers, it is recommended to make a well-named class with an instance method `call`.
+
+`call` accepts the IO-ish object as an argument, parses data that it reads from it,
+and then returns the metadata for the file (if it could recover any) or `nil` if it couldn't. All files pass
+through all parsers by default, so if you are dealing with a file that is not "your" format - return `nil` from
+your method or `break` your Proc as early as possible. A blank `return` works fine too.
+
+The IO will at the minimum support the subset of the IO API defined in `IOConstraint`
+
+Strictly, a parser should be one of the two things:
+
+1) An object that can be `call()`-ed itself, with an argument that conforms to `IOConstraint`
+2) An object that responds to `new` and returns something that can be `call()`-ed with the same convention.
+
+The second opton is useful for parsers that are stateful and non-reentrant. It also provides better automatic
+instrumentation names for metrics sourced to `Measurometer` automatically. 
+
+FormatParser is made to be used in threaded environments, and if you use instance variables
+you need your parser to be isolated from it's siblings in other threads - therefore you can pass
+a Class on registration to have your parser instantiated for each `call()`, anew.
+
+Your parser has to be registered using `FormatParser.register_parser` with the information on the formats
+and file natures it provides.
+
+Down below you can find the most basic parser implementation:
+
+```ruby
+MyParser = ->(io) {
+  # ... do some parsing with `io`
+  magic_bytes = io.read(4)
+  # breaking the block returns `nil` to the caller signaling "no match"
+  break if magic_bytes != 'IMGA'
+
+  parsed_witdh, parsed_height = io.read(8).unpack('VV')
+  # ...and return the FileInformation::Image object with the metadata.
+  FormatParser::Image.new(
+    width_px: parsed_width,
+    height_px: parsed_height,
+  )
+}
+
+# Register the parser with the module, so that it will be applied to any
+# document given to `FormatParser.parse()`. The supported natures are currently
+#      - :audio
+#      - :document
+#      - :image
+#      - :video
+FormatParser.register_parser MyParser, natures: :image, formats: :bmp
+```
+
+If you are using a class, this is the skeleton to use:
+
+```ruby
+class MyParser
+  def call(io)
+    # ... do some parsing with `io`
+    # The instance will be discarded after parsing, so using instance variables
+    # is permitted - they are not shared between calls to `call`
+    @magic_bytes = io.read(4)
+    break if @magic_bytes != 'IMGA'
+    parsed_witdh, parsed_height = io.read(8).unpack('VV')
+    FormatParser::Image.new(
+      width_px: parsed_width,
+      height_px: parsed_height,
+    )
+  end
+
+  FormatParser.register_parser self, natures: :image, formats: :bmp
+end
+```
+
 ## Pull requests
 
 Good pull requests-patches, improvements, new features-are a fantastic

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ JSON.pretty_generate(img_info) #=> ...
 
 ## Creating your own parsers
 
-See the [section on writing parsers in CONTRIBUTING.md](CONTRIBUTING.md##so-you-want-to-contribute-a-new-parser)
+See the [section on writing parsers in CONTRIBUTING.md](CONTRIBUTING.md#so-you-want-to-contribute-a-new-parser)
 
 ## Design rationale
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,24 @@ and [dimensions,](https://github.com/sstephenson/dimensions) borrowing from them
 
 ## Currently supported filetypes:
 
-`TIFF, CR2, PSD, PNG, MP3, JPEG, GIF, PDF, DPX, AIFF, WAV, FDX, MOV, MP4, M4A, FLAC, DOCX, PPTX, XLSX`
+* TIFF
+* CR2
+* PSD
+* PNG
+* MP3
+* JPEG
+* GIF
+* PDF
+* DPX
+* AIFF
+* WAV
+* FLAC
+* FDX
+* MOV
+* MP4
+* M4A
+* ZIP
+* DOCX, PPTX, XLSX
 
 ...with [more](https://github.com/WeTransfer/format_parser/issues?q=is%3Aissue+is%3Aopen+label%3Aformats) on the way!
 
@@ -32,7 +49,7 @@ match.orientation   #=> :top_left
 If you would rather receive all potential results from the gem, call the gem as follows:
 
 ```ruby
-FormatParser.parse(File.open("myimage.jpg", "rb"), results: :all)
+array_of_results = FormatParser.parse(File.open("myimage.jpg", "rb"), results: :all)
 ```
 
 You can also optimize the metadata extraction by providing hints to the gem:
@@ -50,69 +67,7 @@ JSON.pretty_generate(img_info) #=> ...
 
 ## Creating your own parsers
 
-In order to create new parsers, you have to write a method or a  Proc that accepts an IO and performs the
-parsing, and then returns the metadata for the file (if it could recover any) or `nil` if it couldn't. All files pass
-through all parsers by default, so if you are dealing with a file that is not "your" format - return `nil` from
-your method or `break` your Proc as early as possible. A blank `return` works fine too.
-
-The IO will at the minimum support the subset of the IO API defined in `IOConstraint`
-
-Strictly, a parser should be one of the two things:
-
-1) An object that can be `call()`-ed itself, with an argument that conforms to `IOConstraint`
-2) An object that responds to `new` and returns something that can be `call()`-ed with the same convention.
-
-The second opton is useful for parsers that are stateful and non-reentrant. FormatParser is made to be used in
-threaded environments, and if you use instance variables you need your parser to be isolated from it's siblings in
-other threads - therefore you can pass a Class on registration to have your parser instantiated for each `call()`,
-anew.
-
-Your parser has to be registered using `FormatParser.register_parser` with the information on the formats
-and file natures it provides.
-
-Down below you can find a basic parser implementation:
-
-```ruby
-MyParser = ->(io) {
-  # ... do some parsing with `io`
-  magic_bytes = io.read(4)
-  break if magic_bytes != 'XBMP'
-  # ... more parsing code
-  # ...and return the FileInformation::Image object with the metadata.
-  FormatParser::Image.new(
-    width_px: parsed_width,
-    height_px: parsed_height,
-  )
-}
-
-# Register the parser with the module, so that it will be applied to any
-# document given to `FormatParser.parse()`. The supported natures are currently
-#      - :audio
-#      - :document
-#      - :image
-#      - :video
-FormatParser.register_parser MyParser, natures: :image, formats: :bmp
-```
-
-If you are using a class, this is the skeleton to use:
-
-```ruby
-class MyParser
-  def call(io)
-    # ... do some parsing with `io`
-    magic_bytes = io.read(4)
-    return unless magic_bytes == 'XBMP'
-    # ... more parsing code
-    # ...and return the FileInformation::Image object with the metadata.
-    FormatParser::Image.new(
-      width_px: parsed_width,
-      height_px: parsed_height,
-    )
-  end
-
-  FormatParser.register_parser self, natures: :image, formats: :bmp
-end
-```
+See the [section on writing parsers in CONTRIBUTING.md](CONTRIBUTING.md##so-you-want-to-contribute-a-new-parser)
 
 ## Design rationale
 


### PR DESCRIPTION
Move the documentation on writing parsers into CONTRIBUTING as the README should be a no-frills way of _using_ the library first.