### PR TITLE
Speed up JPEG parser for invalid inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Make JPEG parser bail out earlier if no marker can be found for 1024KB of raw data
+
 ## 0.9.0
 * Add a parser for the BMP image file format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Make JPEG parser bail out earlier if no marker can be found for 1024KB of raw data
+* Make JPEG parser bail out earlier if no marker is found while scanning through 1024 bytes of data
 
 ## 0.9.0
 * Add a parser for the BMP image file format

--- a/spec/parsers/jpeg_parser_spec.rb
+++ b/spec/parsers/jpeg_parser_spec.rb
@@ -50,8 +50,17 @@ describe FormatParser::JPEGParser do
   end
 
   it 'does not continue parsing for inordinate amount of time if the file contains no 0xFF bytes' do
-    bytes_except_null_byte = 0x0..0xFE
-    no_markers = ([0xFF, 0xD8] + (16 * 1024).times.map { rand(bytes_except_null_byte) }).pack('C*')
+    # Create a large fuzzed input that consists of any bytes except 0xFF,
+    # so that the marker detector has nothing to latch on to
+    bytes_except_byte_255 = 0x0..0xFE
+
+    # Start the blob with the usual SOI marker - 0xFF 0xD8, so that the parser does not
+    # bail out too early and actually "bites" into the blob
+    no_markers = ([0xFF, 0xD8] + (16 * 1024).times.map { rand(bytes_except_byte_255) }).pack('C*')
+
+    # Yes, assertions on a private method - but we want to ensure we do not read more
+    # single bytes than the restriction stipulates we may. At the same time we check that
+    # the method does indeed, get triggered
     expect(subject).to receive(:read_char).at_least(100).times.at_most(1024).times.and_call_original
     result = subject.call(StringIO.new(no_markers))
     expect(result).to be_nil


### PR DESCRIPTION
Previously we could keep scanning JPEG files until reaching the read limits,
which was also slow because of the incurred read/unpack/first calls for each
byte. This could lead to parse calls for, say, PSD files take 3-4 seconds since
we would be looking for a marker and not finding it and would just keep reading
one byte at a time.

This will make read_next_marker fail earlier if it cannot find a marker sequence
after "blind scanning" 1024 bytes.