### PR TITLE
Fix parsing of JPEGs with lots of APP1 markers, fix JPEG/MP3 mislabeling

### DIFF
--- a/lib/attributes_json.rb
+++ b/lib/attributes_json.rb
@@ -20,6 +20,7 @@ module FormatParser::AttributesJSON
     methods.grep(/\w\=$/).each_with_object(h) do |attr_writer_method_name, h|
       reader_method_name = attr_writer_method_name.to_s.gsub(/\=$/, '')
       value = public_send(reader_method_name)
+      value = nil if value == Float::INFINITY
       # When calling as_json on our members there is no need to pass the root: option given to us
       # by the caller
       h[reader_method_name] = value.respond_to?(:as_json) ? value.as_json : value

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -83,6 +83,10 @@ class FormatParser::MP3Parser
     est_samples = est_frame_count * SAMPLES_PER_FRAME
     est_duration_seconds = est_samples / avg_sample_rate
 
+    # Safeguard for i.e. some JPEGs being recognized as MP3
+    # to prevent ambiguous recognition
+    return if est_duration_seconds == Float::INFINITY
+
     file_info.media_duration_seconds = est_duration_seconds
     file_info
   end

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -2,6 +2,8 @@
 class FormatParser::ReadLimiter
   NO_LIMIT = nil
 
+  attr_reader :seeks, :reads, :bytes
+
   class BudgetExceeded < StandardError
   end
 

--- a/lib/read_limits_config.rb
+++ b/lib/read_limits_config.rb
@@ -1,5 +1,5 @@
 class FormatParser::ReadLimitsConfig
-  MAX_PAGE_FAULTS = 8
+  MAX_PAGE_FAULTS = 16
 
   def initialize(total_bytes_available_per_parser)
     @max_read_bytes_per_parser = total_bytes_available_per_parser.to_i

--- a/spec/attributes_json_spec.rb
+++ b/spec/attributes_json_spec.rb
@@ -27,6 +27,21 @@ describe FormatParser::AttributesJSON do
     end
   end
 
+  it 'converts Float::INFINITY to nil' do
+    anon_class = Class.new do
+      include FormatParser::AttributesJSON
+      attr_accessor :some_infinity
+      def some_infinity
+        Float::INFINITY
+      end
+    end
+    instance = anon_class.new
+    output = JSON.dump(instance)
+    readback = JSON.parse(output, symbolize_names: true)
+    expect(readback).to have_key(:some_infinity)
+    expect(readback[:some_infinity]).to be_nil
+  end
+
   it 'provides a default implementation of to_json as well' do
     anon_class = Class.new do
       include FormatParser::AttributesJSON

--- a/spec/parsers/jpeg_parser_spec.rb
+++ b/spec/parsers/jpeg_parser_spec.rb
@@ -49,6 +49,19 @@ describe FormatParser::JPEGParser do
     expect(result.intrinsics).to eq(exif_pixel_x_dimension: 8214, exif_pixel_y_dimension: 5476)
   end
 
+  it 'reads an example with many APP1 markers at the beginning of which none are EXIF' do
+    fixture_path = fixtures_dir + '/JPEG/UNVIEWABLE_many_APP1_markers_before_sos.jpg'
+    io = FormatParser::ReadLimiter.new(File.open(fixture_path, 'rb'))
+
+    result = subject.call(io)
+
+    expect(result).not_to be_nil
+    expect(result.width_px).to eq(1920)
+    expect(result.height_px).to eq(1200)
+
+    expect(io.reads).to be_within(1024).of(1349)
+  end
+
   it 'does not continue parsing for inordinate amount of time if the file contains no 0xFF bytes' do
     # Create a large fuzzed input that consists of any bytes except 0xFF,
     # so that the marker detector has nothing to latch on to

--- a/spec/parsers/mp3_parser_spec.rb
+++ b/spec/parsers/mp3_parser_spec.rb
@@ -44,4 +44,11 @@ describe FormatParser::MP3Parser do
 
     expect(parsed.intrinsics).not_to be_nil
   end
+
+  it 'avoids returning a result when the parsed duration is infinite' do
+    fpath = fixtures_dir + '/JPEG/UNVIEWABLE_many_APP1_markers_before_sos.jpg'
+    parsed = subject.call(File.open(fpath, 'rb'))
+
+    expect(parsed).to be_nil
+  end
 end

--- a/spec/read_limiter_spec.rb
+++ b/spec/read_limiter_spec.rb
@@ -18,6 +18,18 @@ describe FormatParser::ReadLimiter do
     expect(reader.pos).to eq(2)
   end
 
+  it 'exposes #reads, #seeks, #bytes' do
+    reader = FormatParser::ReadLimiter.new(io)
+    expect(reader.pos).to eq(0)
+    reader.read(2)
+    reader.seek(3)
+    reader.seek(4)
+
+    expect(reader.reads).to eq(1)
+    expect(reader.bytes).to eq(2)
+    expect(reader.seeks).to eq(2)
+  end
+
   it 'enforces the number of seeks' do
     reader = FormatParser::ReadLimiter.new(io, max_seeks: 4)
     4.times { reader.seek(1) }


### PR DESCRIPTION
We would read each APP1 marker as if it were useful and then determine whether this APP1 marker was EXIF. What we should do instead is read the first N bytes of the marker, check if it is EXIF, and only then proceed to read the entirety of the marker for passing to EXIFR. This spares on reads.

We also have a problem where some files get mislabeled as MP3 and the metadata gets returned with a duration of Float::INFINITY. When this happens we should instead avoid returning a result altogether, since this is most likely not an MP3 at all.

And we need to bump the number of permitted pagefaults again so that we can churn through those JPEGs with lots of APP1, since reading them unfortunately happens page-per-page even if we read from those pages economically