### PR TITLE
Add a binary called `format_parser_inspect`

### DIFF
--- a/exe/format_parser_inspect
+++ b/exe/format_parser_inspect
@@ -6,15 +6,15 @@ require 'optparse'
 
 options = {results: :first}
 OptionParser.new do |opts|
-  opts.banner = "Usage: format_parser_inspect --first my_file.jpg"
-  opts.on("-a", "--all", "Return all results instead of just the first one") do |v|
+  opts.banner = 'Usage: format_parser_inspect --first my_file.jpg'
+  opts.on('-a', '--all', 'Return all results instead of just the first one') do |_v|
     options[:results] = :all
   end
-  opts.on("--natures[=NATURES]", "Only scan specific natures (comma-separated: image, audio)", Array) do |v|
-    options[:natures] = v.map {|e| e.strip.downcase.to_sym }
+  opts.on('--natures[=NATURES]', 'Only scan specific natures (comma-separated: image, audio)', Array) do |v|
+    options[:natures] = v.map { |e| e.strip.downcase.to_sym }
   end
-  opts.on("--formats[=FORMATS]", "Only scan specific formats (comma-separated: jpg, tif)", Array) do |v|
-    options[:formats] = v.map {|e| e.strip.downcase.to_sym }
+  opts.on('--formats[=FORMATS]', 'Only scan specific formats (comma-separated: jpg, tif)', Array) do |v|
+    options[:formats] = v.map { |e| e.strip.downcase.to_sym }
   end
 end.parse!
 
@@ -24,7 +24,7 @@ return_values = ARGV.map do |path_or_url|
   result_or_results = FormatParser.public_send(method_name, path_or_url, **options)
   if options[:results] != :first
     did_detect = true if result_or_results.any?
-    result_map = {
+    {
       source_path_or_url: path_or_url,
       options: options,
       ambiguous: result_or_results.length > 1,
@@ -33,7 +33,7 @@ return_values = ARGV.map do |path_or_url|
   else
     single_result = FormatParser.public_send(method_name, path_or_url, **options)
     did_detect = true if single_result
-    result_map = {
+    {
       source_path_or_url: path_or_url,
       options: options,
       result: result_or_results,

--- a/exe/format_parser_inspect
+++ b/exe/format_parser_inspect
@@ -31,12 +31,11 @@ return_values = ARGV.map do |path_or_url|
       results: result_or_results,
     }
   else
-    single_result = FormatParser.public_send(method_name, path_or_url, **options)
-    did_detect = true if single_result
+    did_detect = true if result_or_results
     {
       source_path_or_url: path_or_url,
       options: options,
-      result: single_result,
+      result: result_or_results,
     }
   end
 end

--- a/exe/format_parser_inspect
+++ b/exe/format_parser_inspect
@@ -36,7 +36,7 @@ return_values = ARGV.map do |path_or_url|
     {
       source_path_or_url: path_or_url,
       options: options,
-      result: result_or_results,
+      result: single_result,
     }
   end
 end

--- a/exe/format_parser_inspect
+++ b/exe/format_parser_inspect
@@ -20,7 +20,7 @@ end.parse!
 
 did_detect = false
 return_values = ARGV.map do |path_or_url|
-  method_name = path_or_url.start_with?('http') ? :parse_http : :parse_file_at
+  method_name = path_or_url =~ /^http(s?)\:\/\// ? :parse_http : :parse_file_at
   result_or_results = FormatParser.public_send(method_name, path_or_url, **options)
   if options[:results] != :first
     did_detect = true if result_or_results.any?

--- a/exe/format_parser_inspect
+++ b/exe/format_parser_inspect
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/format_parser'
+require 'json'
+require 'optparse'
+
+options = {results: :first}
+OptionParser.new do |opts|
+  opts.banner = "Usage: format_parser_inspect --first my_file.jpg"
+  opts.on("-a", "--all", "Return all results instead of just the first one") do |v|
+    options[:results] = :all
+  end
+  opts.on("--natures[=NATURES]", "Only scan specific natures (comma-separated: image, audio)", Array) do |v|
+    options[:natures] = v.map {|e| e.strip.downcase.to_sym }
+  end
+  opts.on("--formats[=FORMATS]", "Only scan specific formats (comma-separated: jpg, tif)", Array) do |v|
+    options[:formats] = v.map {|e| e.strip.downcase.to_sym }
+  end
+end.parse!
+
+did_detect = false
+return_values = ARGV.map do |path_or_url|
+  method_name = path_or_url.start_with?('http') ? :parse_http : :parse_file_at
+  result_or_results = FormatParser.public_send(method_name, path_or_url, **options)
+  if options[:results] != :first
+    did_detect = true if result_or_results.any?
+    result_map = {
+      source_path_or_url: path_or_url,
+      options: options,
+      ambiguous: result_or_results.length > 1,
+      results: result_or_results,
+    }
+  else
+    single_result = FormatParser.public_send(method_name, path_or_url, **options)
+    did_detect = true if single_result
+    result_map = {
+      source_path_or_url: path_or_url,
+      options: options,
+      result: result_or_results,
+    }
+  end
+end
+
+puts JSON.pretty_generate(return_values)
+did_detect ? exit(0) : exit(1)

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -72,6 +72,18 @@ module FormatParser
     parse(RemoteIO.new(url), **kwargs)
   end
 
+  # Parses the file at the given `path` and returns the results as if it were any IO
+  # given to `.parse`. The accepted keyword arguments are the same as the ones for `parse`.
+  #
+  # @param path[String] the path to the file to parse on the local filesystem
+  # @param kwargs the keyword arguments to be delegated to `.parse`
+  # @see {.parse}
+  def self.parse_file_at(path, **kwargs)
+    File.open(path, 'rb') do |io|
+      parse(io, **kwargs)
+    end
+  end
+
   # Parses the resource contained in the given IO-ish object, and returns either the first matched
   # result (omitting all the other parsers), the first N results or all results.
   #

--- a/spec/format_parser_inspect_spec.rb
+++ b/spec/format_parser_inspect_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'shellwords'
+
+describe '/exe/format_parser_inspect binary' do
+  let(:bin_path) do
+    Shellwords.escape(File.expand_path(__dir__ + '/../exe/format_parser_inspect'))
+  end
+
+  it 'performs parsing on full default' do
+    fixture_path = fixtures_dir + 'JPEG/divergent_pixel_dimensions_exif.jpg'
+
+    result = `#{bin_path} #{Shellwords.escape(fixture_path)}`
+
+    retval = JSON.parse(result, symbolize_names: true)
+    parsed_result = retval.first
+    expect(parsed_result[:source_path_or_url]).to end_with('divergent_pixel_dimensions_exif.jpg')
+    expect(parsed_result[:options][:results]).to eq('first')
+    expect(parsed_result[:result]).not_to be_nil
+  end
+
+  it 'performs parsing with --all' do
+    fixture_path = fixtures_dir + 'JPEG/divergent_pixel_dimensions_exif.jpg'
+
+    result = `#{bin_path} --all #{Shellwords.escape(fixture_path)}`
+
+    retval = JSON.parse(result, symbolize_names: true)
+    parsed_result = retval.first
+    expect(parsed_result[:source_path_or_url]).to end_with('divergent_pixel_dimensions_exif.jpg')
+    expect(parsed_result[:options][:results]).to eq('all')
+    expect(parsed_result[:ambiguous]).to eq(false)
+    expect(parsed_result[:results]).not_to be_empty
+  end
+
+  it 'performs parsing with --natures option' do
+    fixture_path = fixtures_dir + 'JPEG/divergent_pixel_dimensions_exif.jpg'
+
+    result = `#{bin_path} --natures=IMAGE #{Shellwords.escape(fixture_path)}`
+
+    retval = JSON.parse(result, symbolize_names: true)
+    parsed_result = retval.first
+    expect(parsed_result[:source_path_or_url]).to end_with('divergent_pixel_dimensions_exif.jpg')
+    expect(parsed_result[:options][:natures]).to eq(['image'])
+    expect(parsed_result[:result]).not_to be_nil
+  end
+
+  it 'performs parsing with --formats option' do
+    fixture_path = fixtures_dir + 'JPEG/divergent_pixel_dimensions_exif.jpg'
+
+    result = `#{bin_path} --formats=zip #{Shellwords.escape(fixture_path)}`
+
+    retval = JSON.parse(result, symbolize_names: true)
+    parsed_result = retval.first
+    expect(parsed_result[:source_path_or_url]).to end_with('divergent_pixel_dimensions_exif.jpg')
+    expect(parsed_result[:options][:formats]).to eq(['zip'])
+    expect(parsed_result[:result]).to be_nil
+  end
+end

--- a/spec/format_parser_spec.rb
+++ b/spec/format_parser_spec.rb
@@ -47,7 +47,7 @@ describe FormatParser do
     let(:audio) { FormatParser::Audio.new(format: :aiff, num_audio_channels: 1) }
     let(:image) { FormatParser::Image.new(format: :dpx, width_px: 1, height_px: 1) }
 
-    context '#parse called hash options' do
+    context '.parse called with options' do
       before do
         expect_any_instance_of(FormatParser::AIFFParser).to receive(:call).and_return(audio)
         expect_any_instance_of(FormatParser::DPXParser).to receive(:call).and_return(image)
@@ -59,7 +59,7 @@ describe FormatParser do
       it { is_expected.to include(audio) }
     end
 
-    context '#parse called without hash options' do
+    context '.parse called without hash options' do
       before do
         expect_any_instance_of(FormatParser::DPXParser).to receive(:call).and_return(image)
       end
@@ -67,6 +67,14 @@ describe FormatParser do
       subject { FormatParser.parse(blob) }
 
       it { is_expected.to eq(image) }
+    end
+  end
+
+  describe '.parse_file_at' do
+    it 'parses a fixture when given a path to it' do
+      path = fixtures_dir + '/WAV/c_M1F1-Alaw-AFsp.wav'
+      result = FormatParser.parse_file_at(path)
+      expect(result.nature).to eq(:audio)
     end
   end
 


### PR DESCRIPTION
which allows you to get output from format_parser without doing it from code. This is primarily useful when debugging format detection issues, but can also be used as a shortcut to determine what the file actually is. Think about it as $file on steroids.

It will print detection information on STDOUT in JSON, so `jq` can be used on the output. Use it like so:

```
$ ./exe/format_parser_inspect /path/to/somefile.jpg
```