### PR TITLE
Fix TIFF parser regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix a TIFF parsing regression introduced in 0.3.1 that led to all TIFFs being incorrectly parsed
+
 ## 0.9.3
 * Fix a JPEG parsing regression introduced in 0.9.1
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Unless specified otherwise in this section the fixture files are MIT licensed an
 ### M4A
 - fixture.m4a was created by one of the project maintainers and is MIT licensed
 
+### TIFF
+- `Shinbutsureijoushuincho.tiff` is obtained from Wikimedia Commons and is Creative Commons licensed
+- `IMG_9266_*.tif` and all it's variations were created by the project maintainers
+
 ### ZIP
 - The .zip fixture files have been created by the project maintainers
 

--- a/spec/parsers/tiff_parser_spec.rb
+++ b/spec/parsers/tiff_parser_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe FormatParser::TIFFParser do
-  describe 'is able to parse all the examples from FastImage' do
+  describe 'with FastImage TIFF examples' do
     Dir.glob(fixtures_dir + '/TIFF/*.tif').each do |tiff_path|
       it "is able to parse #{File.basename(tiff_path)}" do
         parsed = subject.call(File.open(tiff_path, 'rb'))
@@ -15,6 +15,48 @@ describe FormatParser::TIFFParser do
 
         expect(parsed.height_px).to be_kind_of(Integer)
         expect(parsed.height_px).to be > 0
+      end
+    end
+  end
+
+  it 'extracts dimensions from a very large TIFF economically' do
+    tiff_path = fixtures_dir + '/TIFF/Shinbutsureijoushuincho.tiff'
+
+    io = File.open(tiff_path, 'rb')
+    io_with_stats = FormatParser::ReadLimiter.new(io)
+
+    parsed = subject.call(io_with_stats)
+
+    expect(parsed).not_to be_nil
+    expect(parsed.width_px).to eq(1120)
+    expect(parsed.height_px).to eq(1559)
+
+    expect(io_with_stats.reads).to be_within(4).of(4)
+    expect(io_with_stats.seeks).to be_within(4).of(4)
+    expect(io_with_stats.bytes).to be_within(1024).of(8198)
+  end
+
+  it 'correctly extracts dimensions for one fixture' do
+    tiff_path = fixtures_dir + '/TIFF/IMG_9266_8b_rgb_le_interleaved.tif'
+
+    parsed = subject.call(File.open(tiff_path, 'rb'))
+
+    expect(parsed).not_to be_nil
+    expect(parsed.width_px).to eq(320)
+    expect(parsed.height_px).to eq(240)
+  end
+
+  describe 'correctly extracts dimensions from various TIFF flavors of the same file' do
+    Dir.glob(fixtures_dir + '/TIFF/IMG_9266*.tif').each do |tiff_path|
+      it "is able to parse #{File.basename(tiff_path)}" do
+        parsed = subject.call(File.open(tiff_path, 'rb'))
+
+        expect(parsed).not_to be_nil
+        expect(parsed.nature).to eq(:image)
+        expect(parsed.format).to eq(:tif)
+
+        expect(parsed.width_px).to eq(320)
+        expect(parsed.height_px).to eq(240)
       end
     end
   end
@@ -34,9 +76,9 @@ describe FormatParser::TIFFParser do
     end
   end
 
-  describe 'is able to return nil when parsing CR2 examples' do
+  describe 'bails out on CR2 files, such as' do
     Dir.glob(fixtures_dir + '/CR2/*.CR2').each do |cr2_path|
-      it "is able to return nil when parsing #{File.basename(cr2_path)}" do
+      it "skips #{File.basename(cr2_path)}" do
         parsed = subject.call(File.open(cr2_path, 'rb'))
         expect(parsed).to be_nil
       end


### PR DESCRIPTION
When we introduced CR2 (or at some other point) we created
a regression in the TIFF parser and it started reading the image
dimensions from all the wrong places. This resulted in some TIFFs
being recognized as having the image width/height of 1, which
was quite unfortunate.

Knowing that we have chosen, willingly, to have EXIFR at
our disposal, we will delegate parsing to it - it does
it fairly sanely, skips over the image content and reads
the minimum amount of data needed. And the best code is
code you don't have.

It also demonstrates, yet again, that asserting that
"this parser returns an Integer for width" is not
sufficient to make claims of any order, and we
probably should pay attention more when writing tests.
This is the third time we are encountering the pattern.

Also: yes, it's a TIFF.