### PR TITLE
S - Add "display" dimensions in addition to pixel buffer dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `Image#display_width_px` and `Image#display_height_px` for EXIF/aspect corrected display dimensions, and provide
+  those values from a few parsers already. Also make full EXIF data available for JPEG/TIFF in `intrinsics[:exif]`
 * Adds `limits_config` option to `FormatParser.parse()` for tweaking buffers and read limits externally
 
 ## 0.10.0

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Pass an IO object that responds to `read` and `seek` to `FormatParser` and the f
 match = FormatParser.parse(File.open("myimage.jpg", "rb"))
 match.nature        #=> :image
 match.format        #=> :jpg
-match.width_px      #=> 320
-match.height_px     #=> 240
+match.display_width_px      #=> 320
+match.display_height_px     #=> 240
 match.orientation   #=> :top_left
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Unless specified otherwise in this section the fixture files are MIT licensed an
 ### FDX
 - fixture.fdx was created by one of the project maintainers and is MIT licensed
 
+### DPX
+- DPX files were created by one of the project maintainers and may be used with the library for the purposes of testing
+
 ### MOOV
 - bmff.mp4 is borrowed from the [bmff](https://github.com/zuku/bmff) project
 - Test_Circular MOV files were created by one of the project maintainers and are MIT licensed

--- a/lib/exif_flip_dimensions.rb
+++ b/lib/exif_flip_dimensions.rb
@@ -1,0 +1,7 @@
+module FormatParser::ExifFlipDimensions
+  NORMAL_ORIENTATIONS = [:bottom_left, :bottom_right, :top_left, :top_right]
+
+  def rotated?(exif_orientation_sym)
+    NORMAL_ORIENTATIONS.include?(exif_orientation_sym) ? false : true
+  end
+end

--- a/lib/exif_flip_dimensions.rb
+++ b/lib/exif_flip_dimensions.rb
@@ -1,7 +1,0 @@
-module FormatParser::ExifFlipDimensions
-  NORMAL_ORIENTATIONS = [:bottom_left, :bottom_right, :top_left, :top_right]
-
-  def rotated?(exif_orientation_sym)
-    NORMAL_ORIENTATIONS.include?(exif_orientation_sym) ? false : true
-  end
-end

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -15,7 +15,6 @@ module FormatParser
   require_relative 'remote_io'
   require_relative 'io_constraint'
   require_relative 'care'
-  require_relative 'exif_flip_dimensions'
 
   # Is used to manage access to the shared array of parser constructors, which might
   # potentially be mutated from different threads. The mutex won't be hit too often

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -15,6 +15,7 @@ module FormatParser
   require_relative 'remote_io'
   require_relative 'io_constraint'
   require_relative 'care'
+  require_relative 'exif_flip_dimensions'
 
   # Is used to manage access to the shared array of parser constructors, which might
   # potentially be mutated from different threads. The mutex won't be hit too often

--- a/lib/image.rb
+++ b/lib/image.rb
@@ -18,11 +18,19 @@ module FormatParser
     # Image width when displayed and taking into account things like camera
     # orientation tags and non-square pixels/anamorphicity. The dimensions
     # used for display are always computed by _squashing_, not by _stretching_.
+    #
+    # If the display width/height are not specified, the sizes of the
+    # pixel buffer will get returned instead (values of the `width_px`/`height_px`
+    # attributes)
     attr_accessor :display_width_px
 
     # Image height when displayed and taking into account things like camera
     # orientation tags and non-square pixels/anamorphicity. The dimensions
     # used for display are always computed by _squashing_, not by _stretching_.
+    #
+    # If the display width/height are not specified, the sizes of the
+    # pixel buffer will get returned instead (values of the `width_px`/`height_px`
+    # attributes)
     attr_accessor :display_height_px
 
     # Whether the file has multiple frames (relevant for image files and video)
@@ -59,20 +67,8 @@ module FormatParser
     # Only permits assignments via defined accessors
     def initialize(**attributes)
       attributes.map { |(k, v)| public_send("#{k}=", v) }
-    end
-
-    # If the display width/height are not specified, the sizes of the
-    # pixel buffer will get returned instead (values of the `width_px`/`height_px`
-    # attributes)
-    def display_width_px # rubocop:disable Lint/DuplicateMethods
-      @display_width_px || @width_px
-    end
-
-    # If the display width/height are not specified, the sizes of the
-    # pixel buffer will get returned instead (values of the `width_px`/`height_px`
-    # attributes)
-    def display_height_px # rubocop:disable Lint/DuplicateMethods
-      @display_height_px || @height_px
+      @display_width_px ||= @width_px
+      @display_height_px ||= @height_px
     end
 
     def nature

--- a/lib/image.rb
+++ b/lib/image.rb
@@ -64,14 +64,14 @@ module FormatParser
     # If the display width/height are not specified, the sizes of the
     # pixel buffer will get returned instead (values of the `width_px`/`height_px`
     # attributes)
-    def display_width_px
+    def display_width_px # rubocop:disable Lint/DuplicateMethods
       @display_width_px || @width_px
     end
 
     # If the display width/height are not specified, the sizes of the
     # pixel buffer will get returned instead (values of the `width_px`/`height_px`
     # attributes)
-    def display_height_px
+    def display_height_px # rubocop:disable Lint/DuplicateMethods
       @display_height_px || @height_px
     end
 

--- a/lib/image.rb
+++ b/lib/image.rb
@@ -15,6 +15,16 @@ module FormatParser
     # Number of pixels vertically in the pixel buffer
     attr_accessor :height_px
 
+    # Image width when displayed and taking into account things like camera
+    # orientation tags and non-square pixels/anamorphicity. The dimensions
+    # used for display are always computed by _squashing_, not by _stretching_.
+    attr_accessor :display_width_px
+
+    # Image height when displayed and taking into account things like camera
+    # orientation tags and non-square pixels/anamorphicity. The dimensions
+    # used for display are always computed by _squashing_, not by _stretching_.
+    attr_accessor :display_height_px
+
     # Whether the file has multiple frames (relevant for image files and video)
     attr_accessor :has_multiple_frames
 
@@ -49,6 +59,20 @@ module FormatParser
     # Only permits assignments via defined accessors
     def initialize(**attributes)
       attributes.map { |(k, v)| public_send("#{k}=", v) }
+    end
+
+    # If the display width/height are not specified, the sizes of the
+    # pixel buffer will get returned instead (values of the `width_px`/`height_px`
+    # attributes)
+    def display_width_px
+      @display_width_px || @width_px
+    end
+
+    # If the display width/height are not specified, the sizes of the
+    # pixel buffer will get returned instead (values of the `width_px`/`height_px`
+    # attributes)
+    def display_height_px
+      @display_height_px || @height_px
     end
 
     def nature

--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -1,143 +1,57 @@
+require 'delegate'
+
 class FormatParser::DPXParser
   include FormatParser::IOUtils
-
-  FILE_INFO = [
-    #    :x4,   # magic bytes SDPX, we read them anyway so not in the pattern
-    :x4,   # u32  :image_offset,   :desc => 'Offset to image data in bytes', :req => true
-    :x8,   # char :version, 8,     :desc => 'Version of header format', :req => true
-    :x4,   # u32  :file_size,      :desc => "Total image size in bytes", :req => true
-    :x4,   # u32  :ditto_key,      :desc => 'Whether the basic headers stay the same through the sequence (1 means they do)'
-    :x4,   # u32  :generic_size,   :desc => 'Generic header length'
-    :x4,   # u32  :industry_size,  :desc => 'Industry header length'
-    :x4,   # u32  :user_size,      :desc => 'User header length'
-    :x100, # char :filename, 100,  :desc => 'Original filename'
-    :x24,  # char :timestamp, 24,  :desc => 'Creation timestamp'
-    :x100, # char :creator, 100,   :desc => 'Creator application'
-    :x200, # char :project, 200,   :desc => 'Project name'
-    :x200, # char :copyright, 200, :desc => 'Copyright'
-    :x4,   # u32  :encrypt_key,   :desc => 'Encryption key'
-    :x104, # blanking :reserve, 104
-  ].join
-
-  FILM_INFO = [
-    :x2,  # char :id, 2,          :desc => 'Film mfg. ID code (2 digits from film edge code)'
-    :x2,  # char :type, 2,        :desc => 'Film type (2 digits from film edge code)'
-    :x2,  # char :offset, 2,      :desc => 'Offset in perfs (2 digits from film edge code)'
-    :x6,  # char :prefix, 6,      :desc => 'Prefix (6 digits from film edge code'
-    :x4,  # char :count, 4,       :desc => 'Count (4 digits from film edge code)'
-    :x32, # char :format, 32,     :desc => 'Format (e.g. Academy)'
-    :x4,  # u32 :frame_position,  :desc => 'Frame position in sequence'
-    :x4,  # u32 :sequence_extent, :desc => 'Sequence length'
-    :x4,  # u32 :held_count,      :desc => 'For how many frames the frame is held'
-    :x4,  # r32 :frame_rate,      :desc => 'Frame rate'
-    :x4,  # r32 :shutter_angle,   :desc => 'Shutter angle'
-    :x4,  # char :frame_id, 32,   :desc => 'Frame identification (keyframe)'
-    :x4,  # char :slate, 100,     :desc => 'Slate information'
-    :x4,  # blanking :reserve, 56
-  ].join
-
-  IMAGE_ELEMENT = [
-    :x4,  # u32 :data_sign, :desc => 'Data sign (0=unsigned, 1=signed). Core is unsigned', :req => true
-    #
-    :x4,  # u32 :low_data,      :desc => 'Reference low data code value'
-    :x4,  # r32 :low_quantity,  :desc => 'Reference low quantity represented'
-    :x4,  # u32 :high_data,     :desc => 'Reference high data code value (1023 for 10bit per channel)'
-    :x4,  # r32 :high_quantity, :desc => 'Reference high quantity represented'
-    #
-    :x1,  # u8 :descriptor,   :desc => 'Descriptor for this image element (ie Video or Film), by enum', :req => true
-    # TODO - colirimetry information might be handy to recover,
-    # as well as "bit size per element" (how many bits _per component_ we have) -
-    # this will be different for, say, 8-bit DPX files versus 10-bit etc.
-    :x1,  # u8 :transfer,     :desc => 'Transfer function (ie Linear), by enum', :req => true
-    :x1,  # u8 :colorimetric, :desc => 'Colorimetric (ie YcbCr), by enum', :req => true
-    :x1,  # u8 :bit_size,     :desc => 'Bit size for element (ie 10)', :req => true
-    #
-    :x2,  # u16 :packing,     :desc => 'Packing (0=Packed into 32-bit words, 1=Filled to 32-bit words))', :req => true
-    :x2,  # u16 :encoding,    :desc => "Encoding (0=None, 1=RLE)", :req => true
-    :x4,  # u32 :data_offset, :desc => 'Offset to data for this image element', :req => true
-    :x4,  # u32 :end_of_line_padding, :desc => "End-of-line padding for this image element"
-    :x4,  # u32 :end_of_image_padding, :desc => "End-of-line padding for this image element"
-    :x32, # char :description, 32
-  ].join
-
-  IMAGE_INFO = [
-    :x2, # u16 :orientation, OrientationInfo,    :desc => 'Orientation descriptor',    :req => true
-    :n1, # u16 :number_elements,                   :desc => 'How many elements to scan', :req => true
-    :N1, # u32 :pixels_per_line,                   :desc => 'Pixels per horizontal line', :req => true
-    :N1, # u32 :lines_per_element,                 :desc => 'Line count', :req => true
-    IMAGE_ELEMENT * 8, # 8 IMAGE_ELEMENT structures
-    :x52, # blanking :reserve, 52
-  ].join
-
-  ORIENTATION_INFO = [
-    :x4, #  u32 :x_offset
-    :x4, #  u32 :y_offset
-    #
-    :x4, #  r32 :x_center
-    :x4, #  r32 :y_center
-    #
-    :x4, #  u32 :x_size, :desc => 'Original X size'
-    :x4, #  u32 :y_size, :desc => 'Original Y size'
-    #
-    :x100, #  char :filename, 100, :desc => "Source image filename"
-    :x24,  #  char :timestamp, 24, :desc => "Source image/tape timestamp"
-    :x32,  #  char :device,    32, :desc => "Input device or tape"
-    :x32,  #  char :serial,    32, :desc => "Input device serial number"
-    #
-    :x4,   #  array :border, :u16, 4, :desc => 'Border validity: XL, XR, YT, YB'
-    :x4,
-    :x4,
-    :x4,
-
-    # TODO: - the aspect ratio might be handy to recover since it
-    # will be used in DPX files in, say, anamorphic (non-square pixels)
-    :x4,   #  array :aspect_ratio , :u32, 2, :desc => "Aspect (H:V)"
-    :x4,
-    #
-    :x28,  #  blanking :reserve, 28
-  ].join
-
-  DPX_INFO = [
-    FILE_INFO,
-    IMAGE_INFO,
-    ORIENTATION_INFO,
-  ].join
-
-  DPX_INFO_LE = DPX_INFO.tr('n', 'v').tr('N', 'V')
-
-  SIZEOF = ->(pattern) {
-    bytes_per_element = {
-      'v' => 2, # 16bit uints
-      'n' => 2,
-      'V' => 4, # 32bit uints
-      'N' => 4,
-      'C' => 1,
-      'x' => 1,
-    }
-    pattern.scan(/[^\d]\d+/).map do |pattern|
-      unpack_code = pattern[0]
-      num_repetitions = pattern[1..-1].to_i
-      bytes_per_element.fetch(unpack_code) * num_repetitions
-    end.inject(&:+)
-  }
-
+  require_relative 'dpx_parser/dpx_structs'
   BE_MAGIC = 'SDPX'
   LE_MAGIC = BE_MAGIC.reverse
-  HEADER_SIZE = SIZEOF[DPX_INFO] # Does not include the initial 4 bytes
+
+  class ByteOrderHintIO < SimpleDelegator
+    def initialize(io, is_little_endian)
+      super(io)
+      @little_endian = is_little_endian
+    end
+
+    def le?
+      @little_endian
+    end
+  end
+
+  private_constant :ByteOrderHintIO
 
   def call(io)
     io = FormatParser::IOConstraint.new(io)
-    magic = io.read(4)
-
+    magic = safe_read(io, 4)
     return unless [BE_MAGIC, LE_MAGIC].include?(magic)
 
-    unpack_pattern = DPX_INFO
-    unpack_pattern = DPX_INFO_LE if magic == LE_MAGIC
-    _num_elements, pixels_per_line, num_lines, *_ = safe_read(io, HEADER_SIZE).unpack(unpack_pattern)
+    io.seek(0)
+
+    dpx_structure = DPX.read_and_unpack(ByteOrderHintIO.new(io, magic == LE_MAGIC))
+
+    w = dpx_structure.fetch(:image).fetch(:pixels_per_line)
+    h = dpx_structure.fetch(:image).fetch(:lines_per_element)
+
+    pixel_aspect_w = dpx_structure.fetch(:orientation).fetch(:horizontal_pixel_aspect)
+    pixel_aspect_h = dpx_structure.fetch(:orientation).fetch(:vertical_pixel_aspect)
+    pixel_aspect = pixel_aspect_w / pixel_aspect_h.to_f
+
+    image_aspect = w / h.to_f * pixel_aspect
+
+    display_w = w
+    display_h = h
+    if image_aspect > 1
+      display_h = (display_w / image_aspect).round
+    else
+      display_w = (display_h * image_aspect).round
+    end
+
     FormatParser::Image.new(
       format: :dpx,
-      width_px: pixels_per_line,
-      height_px: num_lines
+      width_px: w,
+      height_px: h,
+      display_width_px: display_w,
+      display_height_px: display_h,
+      intrinsics: dpx_structure,
     )
   end
 

--- a/lib/parsers/dpx_parser/dpx_structs.rb
+++ b/lib/parsers/dpx_parser/dpx_structs.rb
@@ -7,9 +7,10 @@ class FormatParser::DPXParser
     }
 
     class Capture < Struct.new(:pattern, :bytes)
+      include FormatParser::IOUtils
       def read_and_unpack(io)
         platform_byte_order_pattern = io.le? ? TO_LITTLE_ENDIAN.fetch(pattern, pattern) : pattern
-        io.read(bytes).unpack(platform_byte_order_pattern).first
+        safe_read(io, bytes).unpack(platform_byte_order_pattern).first
       end
     end
 

--- a/lib/parsers/dpx_parser/dpx_structs.rb
+++ b/lib/parsers/dpx_parser/dpx_structs.rb
@@ -1,0 +1,228 @@
+class FormatParser::DPXParser
+  # A teeny-tiny rewording of depix (https://rubygems.org/gems/depix)
+  class Binstr
+    TO_LITTLE_ENDIAN = {
+      'N' => 'V',
+      'n' => 'v',
+    }
+
+    class Capture < Struct.new(:pattern, :bytes)
+      def read_and_unpack(io)
+        platform_byte_order_pattern = io.le? ? TO_LITTLE_ENDIAN.fetch(pattern, pattern) : pattern
+        io.read(bytes).unpack(platform_byte_order_pattern).first
+      end
+    end
+
+    def self.fields
+      @fields ||= []
+      @fields
+    end
+
+    def self.char(field_name, length, **_kwargs)
+      fields << [field_name, Capture.new('Z%d' % length, length)]
+    end
+
+    def self.u8(field_name, **_kwargs)
+      fields << [field_name, Capture.new('c', 1)]
+    end
+
+    def self.u16(field_name, **_kwargs)
+      fields << [field_name, Capture.new('n', 2)]
+    end
+
+    def self.u32(field_name, **_kwargs)
+      fields << [field_name, Capture.new('N', 4)]
+    end
+
+    def self.r32(field_name, **_kwargs)
+      fields << [field_name, Capture.new('e', 4)]
+    end
+
+    def self.blanking(field_name, length, **_kwargs)
+      fields << [field_name, Capture.new('x%d' % length, length)]
+    end
+
+    def self.array(field_name, nested_struct_descriptor_or_symbol, n_items, **_kwargs)
+      if nested_struct_descriptor_or_symbol.is_a?(Symbol)
+        n_items.times do |i|
+          public_send(nested_struct_descriptor_or_symbol, '%s_%d' % [field_name, i])
+        end
+      else
+        n_items.times do |i|
+          fields << ['%s_%d' % [field_name, i], nested_struct_descriptor_or_symbol]
+        end
+      end
+    end
+
+    def self.inner(field_name, nested_struct_descriptor, **_kwargs)
+      fields << [field_name, nested_struct_descriptor]
+    end
+
+    def self.cleanup(v)
+      case v
+      when String
+        v.scrub
+      when Float
+        v.nan? ? nil : v
+      else
+        v
+      end
+    end
+
+    def self.read_and_unpack(io)
+      fields.each_with_object({}) do |(field_name, capture), h|
+        maybe_value = cleanup(capture.read_and_unpack(io))
+        h[field_name] = maybe_value unless maybe_value.nil?
+      end
+    end
+  end
+
+  class FileInfo < Binstr
+    char :magic, 4,       desc: 'Endianness (SDPX is big endian)', req: true
+    u32  :image_offset,   desc: 'Offset to image data in bytes', req: true
+    char :version, 8,     desc: 'Version of header format', req: true
+
+    u32  :file_size,      desc: 'Total image size in bytes', req: true
+    u32  :ditto_key,      desc: 'Whether the basic headers stay the same through the sequence (1 means they do)'
+    u32  :generic_size,   desc: 'Generic header length'
+    u32  :industry_size,  desc: 'Industry header length'
+    u32  :user_size,      desc: 'User header length'
+
+    char :filename, 100,  desc: 'Original filename'
+    char :timestamp, 24,  desc: 'Creation timestamp'
+    char :creator, 100,   desc: 'Creator application'
+    char :project, 200,   desc: 'Project name'
+    char :copyright, 200, desc: 'Copyright'
+
+    u32  :encrypt_key,    desc: 'Encryption key'
+    blanking :reserve, 104
+  end
+
+  class FilmInfo < Binstr
+    char :id, 2,          desc: 'Film mfg. ID code (2 digits from film edge code)'
+    char :type, 2,        desc: 'Film type (2 digits from film edge code)'
+    char :offset, 2,      desc: 'Offset in perfs (2 digits from film edge code)'
+    char :prefix, 6,      desc: 'Prefix (6 digits from film edge code'
+    char :count, 4,       desc: 'Count (4 digits from film edge code)'
+    char :format, 32,     desc: 'Format (e.g. Academy)'
+
+    u32 :frame_position,  desc: 'Frame position in sequence'
+    u32 :sequence_extent, desc: 'Sequence length'
+    u32 :held_count,      desc: 'For how many frames the frame is held'
+
+    r32 :frame_rate,      desc: 'Frame rate'
+    r32 :shutter_angle,   desc: 'Shutter angle'
+
+    char :frame_id, 32,   desc: 'Frame identification (keyframe)'
+    char :slate, 100,     desc: 'Slate information'
+    blanking :reserve, 56
+  end
+
+  class ImageElement < Binstr
+    u32 :data_sign, desc: 'Data sign (0=unsigned, 1=signed). Core is unsigned', req: true
+
+    u32 :low_data,      desc: 'Reference low data code value'
+    r32 :low_quantity,  desc: 'Reference low quantity represented'
+    u32 :high_data,     desc: 'Reference high data code value (1023 for 10bit per channel)'
+    r32 :high_quantity, desc: 'Reference high quantity represented'
+
+    u8 :descriptor,   desc: 'Descriptor for this image element (ie Video or Film), by enum', req: true
+    u8 :transfer,     desc: 'Transfer function (ie Linear), by enum', req: true
+    u8 :colorimetric, desc: 'Colorimetric (ie YcbCr), by enum', req: true
+    u8 :bit_size,     desc: 'Bit size for element (ie 10)', req: true
+
+    u16 :packing,     desc: 'Packing (0=Packed into 32-bit words, 1=Filled to 32-bit words))', req: true
+    u16 :encoding,    desc: 'Encoding (0=None, 1=RLE)', req: true
+    u32 :data_offset, desc: 'Offset to data for this image element', req: true
+    u32 :end_of_line_padding, desc: 'End-of-line padding for this image element'
+    u32 :end_of_image_padding, desc: 'End-of-line padding for this image element'
+    char :description, 32
+  end
+
+  class OrientationInfo < Binstr
+    u32 :x_offset
+    u32 :y_offset
+
+    r32 :x_center
+    r32 :y_center
+
+    u32 :x_size, desc: 'Original X size'
+    u32 :y_size, desc: 'Original Y size'
+
+    char :filename, 100, desc: 'Source image filename'
+    char :timestamp, 24, desc: 'Source image/tape timestamp'
+    char :device,    32, desc: 'Input device or tape'
+    char :serial,    32, desc: 'Input device serial number'
+
+    array :border, :u16, 4, desc: 'Border validity: XL, XR, YT, YB'
+    u32 :horizontal_pixel_aspect, desc: 'Aspect (H)'
+    u32 :vertical_pixel_aspect, desc: 'Aspect (V)'
+
+    blanking :reserve, 28
+  end
+
+  class TelevisionInfo < Binstr
+    u32 :time_code, desc: 'Timecode, formatted as HH:MM:SS:FF in the 4 higher bits of each 8bit group'
+    u32 :user_bits, desc: 'Timecode UBITs'
+    u8 :interlace,  desc: 'Interlace (0 = noninterlaced; 1 = 2:1 interlace'
+
+    u8 :field_number, desc: 'Field number'
+    u8 :video_signal, desc: 'Video signal (by enum)'
+    u8 :padding,      desc: 'Zero (for byte alignment)'
+
+    r32 :horizontal_sample_rate, desc: 'Horizontal sampling Hz'
+    r32 :vertical_sample_rate,   desc: 'Vertical sampling Hz'
+    r32 :frame_rate,             desc: 'Frame rate'
+    r32 :time_offset,            desc: 'From sync pulse to first pixel'
+    r32 :gamma,                  desc: 'Gamma'
+    r32 :black_level,            desc: 'Black pedestal code value'
+    r32 :black_gain,             desc: 'Black gain code value'
+    r32 :break_point,            desc: 'Break point (?)'
+    r32 :white_level,            desc: 'White level'
+    r32 :integration_times,      desc: 'Integration times (S)'
+    blanking :reserve, 4 # As long as a real
+  end
+
+  class UserInfo < Binstr
+    char :id, 32, desc: 'Name of the user data tag'
+    u32 :user_data_ptr
+  end
+
+  class ImageInfo < Binstr
+    u16 :orientation,                       desc: 'To which orientation descriptor this relates',    req: true
+    u16 :number_elements,                   desc: 'How many elements to scan', req: true
+
+    u32 :pixels_per_line,                   desc: 'Pixels per horizontal line', req: true
+    u32 :lines_per_element,                 desc: 'Line count', req: true
+
+    array :image_elements, ImageElement, 8, desc: 'Image elements'
+
+    blanking :reserve, 52
+
+    # Only expose the elements present
+    def image_elements #:nodoc:
+      @image_elements[0...number_elements]
+    end
+  end
+
+  # This is the main structure represinting headers of one DPX file
+  class DPX < Binstr
+    inner :file, FileInfo,   desc: 'File information', req: true
+    inner :image, ImageInfo, desc: 'Image information', req: true
+    inner :orientation, OrientationInfo, desc: 'Orientation', req: true
+    inner :film, FilmInfo, desc: 'Film industry info', req: true
+    inner :television, TelevisionInfo, desc: 'TV industry info', req: true
+    blanking :user, 32 + 4, desc: 'User info', req: true
+
+    def self.read_and_unpack(io)
+      super.tap do |h|
+        num_elems = h[:image][:number_elements]
+        num_elems.upto(8) do |n|
+          h[:image].delete("image_elements_#{n}")
+        end
+      end
+    end
+  end
+
+  private_constant :Binstr, :FileInfo, :FilmInfo, :ImageElement, :OrientationInfo, :TelevisionInfo, :UserInfo, :ImageInfo
+end

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -1,5 +1,6 @@
 class FormatParser::JPEGParser
   include FormatParser::IOUtils
+  include FormatParser::ExifFlipDimensions
 
   class InvalidStructure < StandardError
   end
@@ -66,13 +67,22 @@ class FormatParser::JPEGParser
 
     # Return at the earliest possible opportunity
     if @width && @height
-      return  FormatParser::Image.new(
+      result = FormatParser::Image.new(
         format: :jpg,
         width_px: @width,
         height_px: @height,
+        display_width_px: @width,
+        display_height_px: @height,
         orientation: @orientation,
         intrinsics: @intrinsics,
       )
+
+      if rotated?(@orientation)
+        result.display_width_px = result.height_px
+        result.display_height_px = result.width_px
+      end
+
+      return result
     end
 
     nil # We could not parse anything

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -1,6 +1,6 @@
 class FormatParser::JPEGParser
   include FormatParser::IOUtils
-  include FormatParser::ExifFlipDimensions
+  include FormatParser::EXIFParser
 
   class InvalidStructure < StandardError
   end
@@ -17,8 +17,6 @@ class FormatParser::JPEGParser
     @buf = FormatParser::IOConstraint.new(io)
     @width             = nil
     @height            = nil
-    @orientation       = nil
-    @intrinsics = {}
     scan
   end
 
@@ -71,16 +69,11 @@ class FormatParser::JPEGParser
         format: :jpg,
         width_px: @width,
         height_px: @height,
-        display_width_px: @width,
-        display_height_px: @height,
-        orientation: @orientation,
-        intrinsics: @intrinsics,
+        display_width_px: @exif_data&.rotated? ? @height : @width,
+        display_height_px: @exif_data&.rotated? ? @width : @height,
+        orientation: @exif_data&.orientation,
+        intrinsics: {exif: @exif_data},
       )
-
-      if rotated?(@orientation)
-        result.display_width_px = result.height_px
-        result.display_height_px = result.width_px
-      end
 
       return result
     end
@@ -148,27 +141,8 @@ class FormatParser::JPEGParser
     exif_data = safe_read(@buf, app1_frame_content_length - EXIF_MAGIC_STRING.bytesize)
 
     FormatParser::Measurometer.add_distribution_value('format_parser.JPEGParser.bytes_sent_to_exif_parser', exif_data.bytesize)
-    scanner = FormatParser::EXIFParser.new(StringIO.new(exif_data))
-    scanner.scan_image_tiff
 
-    @exif_output = scanner.exif_data
-    @orientation = scanner.orientation unless scanner.orientation.nil?
-    @intrinsics[:exif_pixel_x_dimension] = @exif_output.pixel_x_dimension
-    @intrinsics[:exif_pixel_y_dimension] = @exif_output.pixel_y_dimension
-    # Save these two for later, when we decide to provide display width /
-    # display height in addition to pixel buffer width / height. These two
-    # are _different concepts_. Imagine you have an image shot with a camera
-    # in portrait orientation, and the camera has an anamorphic lens. That
-    # anamorpohic lens is a smart lens, and therefore transmits pixel aspect
-    # ratio to the camera, and the camera encodes that aspect ratio into the
-    # image metadata. If we want to know what size our _pixel buffer_ will be,
-    # and how to _read_ the pixel data (stride/interleaving) - we need the
-    # pixel buffer dimensions. If we want to know what aspect and dimensions
-    # our file is going to have _once displayed_ and _once pixels have been
-    # brought to the right orientation_ we need to work with **display dimensions**
-    # which can be remarkably different from the pixel buffer dimensions.
-    @exif_width = scanner.width
-    @exif_height = scanner.height
+    @exif_data = exif_from_tiff_io(StringIO.new(exif_data))
   rescue EXIFR::MalformedTIFF
     # Not a JPEG or the Exif headers contain invalid data, or
     # an APP1 marker was detected in a file that is not a JPEG

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -1,5 +1,6 @@
 class FormatParser::TIFFParser
   include FormatParser::IOUtils
+  include FormatParser::ExifFlipDimensions
 
   MAGIC_LE = [0x49, 0x49, 0x2A, 0x0].pack('C4')
   MAGIC_BE = [0x4D, 0x4D, 0x0, 0x2A].pack('C4')
@@ -18,11 +19,14 @@ class FormatParser::TIFFParser
     scanner.scan_image_tiff
     return unless scanner.exif_data
 
+    w = scanner.exif_data.image_width
+    h = scanner.exif_data.image_length
     FormatParser::Image.new(
       format: :tif,
-      width_px: scanner.exif_data.image_width,
-      height_px: scanner.exif_data.image_length,
-      # might be nil if EXIF metadata wasn't found
+      width_px: w, 
+      height_px: h,
+      display_width_px: rotated?(scanner.orientation) ? h : w,
+      display_height_px: rotated?(scanner.orientation) ? w : h,
       orientation: scanner.orientation
     )
   rescue EXIFR::MalformedTIFF

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -1,6 +1,6 @@
 class FormatParser::TIFFParser
   include FormatParser::IOUtils
-  include FormatParser::ExifFlipDimensions
+  include FormatParser::EXIFParser
 
   MAGIC_LE = [0x49, 0x49, 0x2A, 0x0].pack('C4')
   MAGIC_BE = [0x4D, 0x4D, 0x0, 0x2A].pack('C4')
@@ -15,19 +15,20 @@ class FormatParser::TIFFParser
     # The TIFF scanner in EXIFR is plenty good enough,
     # so why don't we use it? It does all the right skips
     # in all the right places.
-    scanner = FormatParser::EXIFParser.new(io)
-    scanner.scan_image_tiff
-    return unless scanner.exif_data
+    exif_data = exif_from_tiff_io(io)
+    return unless exif_data
 
-    w = scanner.exif_data.image_width
-    h = scanner.exif_data.image_length
+    w = exif_data.image_width
+    h = exif_data.image_length
+
     FormatParser::Image.new(
       format: :tif,
-      width_px: w, 
+      width_px: w,
       height_px: h,
-      display_width_px: rotated?(scanner.orientation) ? h : w,
-      display_height_px: rotated?(scanner.orientation) ? w : h,
-      orientation: scanner.orientation
+      display_width_px: exif_data.rotated? ? h : w,
+      display_height_px: exif_data.rotated? ? w : h,
+      orientation: exif_data.orientation,
+      intrinsics: {exif: exif_data},
     )
   rescue EXIFR::MalformedTIFF
     nil

--- a/spec/attributes_json_spec.rb
+++ b/spec/attributes_json_spec.rb
@@ -42,6 +42,21 @@ describe FormatParser::AttributesJSON do
     expect(readback[:some_infinity]).to be_nil
   end
 
+  it 'converts NaN to nil' do
+    anon_class = Class.new do
+      include FormatParser::AttributesJSON
+      attr_accessor :some_nan
+      def some_nan
+        (1.0 / 0.0).to_f
+      end
+    end
+    instance = anon_class.new
+    output = JSON.dump(instance)
+    readback = JSON.parse(output, symbolize_names: true)
+    expect(readback).to have_key(:some_nan)
+    expect(readback[:some_nan]).to be_nil
+  end
+
   it 'provides a default implementation of to_json as well' do
     anon_class = Class.new do
       include FormatParser::AttributesJSON

--- a/spec/parsers/dpx_parser_spec.rb
+++ b/spec/parsers/dpx_parser_spec.rb
@@ -1,29 +1,33 @@
 require 'spec_helper'
 
 describe FormatParser::DPXParser do
-  describe 'with Depix example files' do
-    Dir.glob(fixtures_dir + '/dpx/*.*').each do |dpx_path|
-      it "is able to parse #{File.basename(dpx_path)}" do
-        parsed = subject.call(File.open(dpx_path, 'rb'))
+  Dir.glob(fixtures_dir + '/dpx/*.*').each do |dpx_path|
+    it "is able to parse #{File.basename(dpx_path)}" do
+      parsed = subject.call(File.open(dpx_path, 'rb'))
 
-        expect(parsed).not_to be_nil
-        expect(parsed.nature).to eq(:image)
-        expect(parsed.format).to eq(:dpx)
+      expect(parsed).not_to be_nil
+      expect(parsed.nature).to eq(:image)
+      expect(parsed.format).to eq(:dpx)
 
-        # If we have an error in the struct offsets these values are likely to become
-        # the maximum value of a 4-byte uint, which is way higher
-        expect(parsed.width_px).to be_kind_of(Integer)
-        expect(parsed.width_px).to be_between(0, 2048)
-        expect(parsed.height_px).to be_kind_of(Integer)
-        expect(parsed.height_px).to be_between(0, 4000)
-      end
+      # If we have an error in the struct offsets these values are likely to become
+      # the maximum value of a 4-byte uint, which is way higher
+      expect(parsed.width_px).to be_kind_of(Integer)
+      expect(parsed.width_px).to be_between(0, 2048)
+      expect(parsed.height_px).to be_kind_of(Integer)
+      expect(parsed.height_px).to be_between(0, 4000)
     end
+  end
 
-    it 'correctly reads pixel dimensions' do
-      fi = File.open(fixtures_dir + '/dpx/026_FROM_HERO_TAPE_5-3-1_MOV.0029.dpx', 'rb')
-      parsed = subject.call(fi)
-      expect(parsed.width_px).to eq(1920)
-      expect(parsed.height_px).to eq(1080)
-    end
+  it 'correctly reads display dimensions corrected for the pixel aspect from the DPX header' do
+    fi = File.open(fixtures_dir + '/dpx/aspect_237_example.dpx', 'rb')
+    parsed = subject.call(fi)
+
+    expect(parsed.width_px).to eq(1920)
+    expect(parsed.height_px).to eq(1080)
+
+    expect(parsed.display_width_px).to eq(1920)
+    expect(parsed.display_height_px).to eq(810)
+
+    expect(parsed.display_width_px / parsed.display_height_px.to_f).to be_within(0.01).of(2.37)
   end
 end

--- a/spec/parsers/dpx_parser_spec.rb
+++ b/spec/parsers/dpx_parser_spec.rb
@@ -30,4 +30,11 @@ describe FormatParser::DPXParser do
 
     expect(parsed.display_width_px / parsed.display_height_px.to_f).to be_within(0.01).of(2.37)
   end
+
+  it 'does not explode on invalid inputs' do
+    invalid = StringIO.new('SDPX' + (' ' * 64))
+    expect {
+      subject.call(invalid)
+    }.to raise_error(FormatParser::IOUtils::InvalidRead)
+  end
 end

--- a/spec/parsers/exif_parser_spec.rb
+++ b/spec/parsers/exif_parser_spec.rb
@@ -1,17 +1,19 @@
 require 'spec_helper'
 
 describe FormatParser::EXIFParser do
+  let(:subject) do
+    Object.new.tap { |o| o.extend FormatParser::EXIFParser }
+  end
+
   describe 'is able to correctly parse orientation for all the TIFF EXIF examples from FastImage' do
     Dir.glob(fixtures_dir + '/exif-orientation-testimages/tiff-*/*.tif').each do |tiff_path|
       filename = File.basename(tiff_path)
       it "is able to parse #{filename}" do
-        parser = FormatParser::EXIFParser.new(File.open(tiff_path, 'rb'))
-        parser.scan_image_tiff
-        expect(parser).not_to be_nil
-
-        expect(parser.orientation).to be_kind_of(Symbol)
+        result = subject.exif_from_tiff_io(File.open(tiff_path, 'rb'))
+        expect(result).not_to be_nil
+        expect(result.orientation).to be_kind_of(Symbol)
         # Filenames in this dir correspond with the orientation of the file
-        expect(filename.include?(parser.orientation.to_s)).to be true
+        expect(filename).to include(result.orientation.to_s)
       end
     end
   end

--- a/spec/parsers/jpeg_parser_spec.rb
+++ b/spec/parsers/jpeg_parser_spec.rb
@@ -26,6 +26,8 @@ describe FormatParser::JPEGParser do
       expect(parsed.orientation).to be_kind_of(Symbol)
       expect(parsed.width_px).to be > 0
       expect(parsed.height_px).to be > 0
+      expect(parsed.display_width_px).to eq(1240)
+      expect(parsed.display_height_px).to eq(1754)
     end
 
     bottom_left_path = fixtures_dir + '/exif-orientation-testimages/jpg/bottom_left.jpg'
@@ -33,12 +35,16 @@ describe FormatParser::JPEGParser do
     expect(parsed.orientation).to eq(:bottom_left)
     expect(parsed.width_px).to eq(1240)
     expect(parsed.height_px).to eq(1754)
+    expect(parsed.display_width_px).to eq(1240)
+    expect(parsed.display_height_px).to eq(1754)
 
     top_right_path = fixtures_dir + '/exif-orientation-testimages/jpg/right_bottom.jpg'
     parsed = subject.call(File.open(top_right_path, 'rb'))
     expect(parsed.orientation).to eq(:right_bottom)
     expect(parsed.width_px).to eq(1754)
     expect(parsed.height_px).to eq(1240)
+    expect(parsed.display_width_px).to eq(1240)
+    expect(parsed.display_height_px).to eq(1754)
   end
 
   it 'gives true pixel dimensions priority over pixel dimensions in EXIF tags' do

--- a/spec/parsers/jpeg_parser_spec.rb
+++ b/spec/parsers/jpeg_parser_spec.rb
@@ -37,6 +37,7 @@ describe FormatParser::JPEGParser do
     expect(parsed.height_px).to eq(1754)
     expect(parsed.display_width_px).to eq(1240)
     expect(parsed.display_height_px).to eq(1754)
+    expect(parsed.intrinsics[:exif]).not_to be_nil
 
     top_right_path = fixtures_dir + '/exif-orientation-testimages/jpg/right_bottom.jpg'
     parsed = subject.call(File.open(top_right_path, 'rb'))
@@ -45,6 +46,7 @@ describe FormatParser::JPEGParser do
     expect(parsed.height_px).to eq(1240)
     expect(parsed.display_width_px).to eq(1240)
     expect(parsed.display_height_px).to eq(1754)
+    expect(parsed.intrinsics[:exif]).not_to be_nil
   end
 
   it 'gives true pixel dimensions priority over pixel dimensions in EXIF tags' do

--- a/spec/parsers/jpeg_parser_spec.rb
+++ b/spec/parsers/jpeg_parser_spec.rb
@@ -50,9 +50,13 @@ describe FormatParser::JPEGParser do
   it 'gives true pixel dimensions priority over pixel dimensions in EXIF tags' do
     jpeg_path = fixtures_dir + '/JPEG/divergent_pixel_dimensions_exif.jpg'
     result = subject.call(File.open(jpeg_path, 'rb'))
+
     expect(result.width_px).to eq(1920)
     expect(result.height_px).to eq(1280)
-    expect(result.intrinsics).to eq(exif_pixel_x_dimension: 8214, exif_pixel_y_dimension: 5476)
+
+    exif = result.intrinsics.fetch(:exif)
+    expect(exif.pixel_x_dimension).to eq(8214)
+    expect(exif.pixel_y_dimension).to eq(5476)
   end
 
   it 'reads an example with many APP1 markers at the beginning of which none are EXIF' do

--- a/spec/parsers/tiff_parser_spec.rb
+++ b/spec/parsers/tiff_parser_spec.rb
@@ -44,6 +44,7 @@ describe FormatParser::TIFFParser do
     expect(parsed).not_to be_nil
     expect(parsed.width_px).to eq(320)
     expect(parsed.height_px).to eq(240)
+    expect(parsed.intrinsics[:exif]).not_to be_nil
   end
 
   describe 'correctly extracts dimensions from various TIFF flavors of the same file' do


### PR DESCRIPTION
In many situations you want to know "What is the resolution of this image with all the EXIF rotations and non-square pixel ratios applied" as opposed to "What is the resolution of the pixel buffer of this image".

IMO we should consider this eventuality and provide conveniences for formats which allow divergent pixel aspects / orientation tagging.