### PR TITLE
Make tests pass with JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ rvm:
 - 2.3.0
 - 2.4.2
 - 2.5.0
-- jruby-9.0
+- jruby-9.1
 sudo: false
 cache: bundler
-matrix:
-  allow_failures:
-    - rvm: jruby-9.0
 script:
   - bundle exec rubocop
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 rvm:
+- 2.2.0
 - 2.3.0
 - 2.4.2
 - 2.5.0
-- jruby-9.1
+- jruby-9.0
 sudo: false
 cache: bundler
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+* Add support for Ruby 2.2.0
+* Fix support for JRuby 9.0
+
 ## 0.12.0
 * Relay upstream status from `RemoteIO` in the `status_code` attribute (returns an `Integer`)
 

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -70,9 +70,9 @@ class FormatParser::JPEGParser
         format: :jpg,
         width_px: @width,
         height_px: @height,
-        display_width_px: @exif_data&.rotated? ? @height : @width,
-        display_height_px: @exif_data&.rotated? ? @width : @height,
-        orientation: @exif_data&.orientation,
+        display_width_px: @exif_data && @exif_data.rotated? ? @height : @width,
+        display_height_px: @exif_data && @exif_data.rotated? ? @width : @height,
+        orientation: @exif_data && @exif_data.orientation,
         intrinsics: {exif: @exif_data},
       )
 

--- a/lib/parsers/zip_parser.rb
+++ b/lib/parsers/zip_parser.rb
@@ -40,7 +40,7 @@ class FormatParser::ZIPParser
 
   def decode_filename(filename, likely_unicode:)
     filename.force_encoding(Encoding::UTF_8) if likely_unicode
-    filename.encode(Encoding::UTF_8, undefined: :replace, replace: UNICODE_REPLACEMENT_CHAR)
+    filename.encode(Encoding::UTF_8, undef: :replace, replace: UNICODE_REPLACEMENT_CHAR)
   end
 
   def decode_filename_of(zip_entry)


### PR DESCRIPTION
Closes #99

- [x] Fix a typo in the zip parser that causes tests to fail with JRuby.
- [x] Add support for Ruby 2.2

