### PR TITLE
Relay upstream status code in RemoteIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.0
+* Relay upstream status from `RemoteIO` in the `status_code` attribute (returns an `Integer`)
+
 ## 0.11.0
 * Add `Image#display_width_px` and `Image#display_height_px` for EXIF/aspect corrected display dimensions, and provide
   those values from a few parsers already. Also make full EXIF data available for JPEG/TIFF in `intrinsics[:exif]`

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end


### PR DESCRIPTION
so that systems using format_parser can relay that
status themselves and ensure requests do not get
repeated for instance