### PR TITLE
Remove uneeded guard when ID3Tag tries to find an unknown genre

### DIFF
--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ks', '~> 0.0.1'
   spec.add_dependency 'exifr', '~> 1.0'
-  spec.add_dependency 'id3tag', '~> 0.10'
+  spec.add_dependency 'id3tag', '~> 0.10', '>= 0.10.1'
   spec.add_dependency 'faraday', '~> 0.13'
 
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -43,10 +43,7 @@ class FormatParser::MP3Parser
     def to_h
       tag = __getobj__
       MEMBERS.each_with_object({}) do |k, h|
-        # ID3Tag sometimes raises when trying to find an unknown genre.
-        # If this guard is removed, it fails when trying to do a gsub on a nil,
-        # in /lib/id3tag/frames/v2/genre_frame/genre_parser_pre_24.rb:25:in `just_genres'
-        value = tag.public_send(k) rescue nil
+        value = tag.public_send(k)
         h[k] = value if value
       end
     end


### PR DESCRIPTION
The guard `rescue nil` can now be safely removed since the original issue
is fixed by https://github.com/krists/id3tag/pull/19

related with: https://github.com/WeTransfer/format_parser/issues/118