### PR TITLE
Fixes bytes_used_by_frames variable calculation

### DIFF
--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -74,7 +74,7 @@ class FormatParser::MP3Parser
     # Compute how many bytes are occupied by the actual MPEG frames
     ignore_bytes_at_tail = id3v1 ? 128 : 0
     ignore_bytes_at_head = io.pos
-    bytes_used_by_frames = io.size - ignore_bytes_at_tail - ignore_bytes_at_tail
+    bytes_used_by_frames = io.size - ignore_bytes_at_head - ignore_bytes_at_tail
 
     io.seek(ignore_bytes_at_head)
 

--- a/spec/parsers/mp3_parser_spec.rb
+++ b/spec/parsers/mp3_parser_spec.rb
@@ -57,7 +57,7 @@ describe FormatParser::MP3Parser do
     expect(parsed.format).to eq(:mp3)
     expect(parsed.num_audio_channels).to eq(2)
     expect(parsed.audio_sample_rate_hz).to eq(44100)
-    expect(parsed.media_duration_seconds).to be_within(0.1).of(1102.46)
+    expect(parsed.media_duration_seconds).to be_within(0.1).of(1098.03)
 
     expect(parsed.intrinsics).not_to be_nil
 


### PR DESCRIPTION
Fixes bytes_used_by_frames variable calculation in FormatParser::MP3Parser class