### PR TITLE
Reset the PDF parser to the utmost basics

### DIFF
--- a/lib/parsers/pdf_parser.rb
+++ b/lib/parsers/pdf_parser.rb
@@ -9,67 +9,12 @@ class FormatParser::PDFParser
   #
   PDF_MARKER = /%PDF-1\.[0-8]{1}/
 
-  # Page counts have different markers depending on
-  # the PDF type. There is not a single common way of solving
-  # this. The only way of solving this correctly is by adding
-  # different types of PDF's in the specs.
-  #
-  COUNT_MARKERS = ['Count ']
-  EOF_MARKER    = '%EOF'
-
   def call(io)
     io = FormatParser::IOConstraint.new(io)
 
     return unless safe_read(io, 9) =~ PDF_MARKER
 
-    attributes = scan_for_attributes(io)
-
-    FormatParser::Document.new(
-      format: :pdf,
-      page_count: attributes[:page_count]
-    )
-  end
-
-  private
-
-  # Read ahead bytes until one of % or / is reached.
-  # A header in a PDF always starts with a /
-  # The % is to detect the EOF
-  #
-  def scan_for_attributes(io)
-    result = {}
-
-    while read = safe_read(io, 1)
-      case read
-      when '%'
-        break if safe_read(io, EOF_MARKER.size) == EOF_MARKER
-      when '/'
-        find_page_count(io, result)
-      end
-    end
-
-    result
-  end
-
-  def find_page_count(io, result)
-    COUNT_MARKERS.each do |marker|
-      if safe_read(io, marker.size) == marker
-        result[:page_count] = read_numbers(io)
-      end
-    end
-  end
-
-  # Read ahead bytes until no more numbers are found
-  # This assumes that the position of io starts at a
-  # number
-  def read_numbers(io)
-    numbers = ''
-
-    while c = safe_read(io, 1)
-      c =~ /\d+/ ? numbers << c : break
-    end
-
-    numbers.to_i
+    FormatParser::Document.new(format: :pdf)
   end
 
   FormatParser.register_parser self, natures: :document, formats: :pdf

--- a/spec/parsers/pdf_parser_spec.rb
+++ b/spec/parsers/pdf_parser_spec.rb
@@ -18,10 +18,6 @@ describe FormatParser::PDFParser do
       expect(parsed_pdf.nature).to eq(:document)
       expect(parsed_pdf.format).to eq(:pdf)
     end
-
-    it 'has a correct page count' do
-      expect(parsed_pdf.page_count).to eq(hash.fetch(:page_count))
-    end
   end
 
   describe 'a PDF file with a missing version header' do
@@ -44,25 +40,9 @@ describe FormatParser::PDFParser do
     pending 'does not parse succesfully'
   end
 
-  describe 'a PDF file with a missing COUNT_HEADER' do
-    let(:pdf_file) { 'missing_page_count.pdf' }
-
-    it 'does not return a page count' do
-      expect(parsed_pdf.page_count).to eq(nil)
-    end
-  end
-
   describe 'parses a PDF file' do
     describe 'a single page file' do
-      include_examples :behave_like_pdf, file: '1_page.pdf', page_count: 1
-    end
-
-    describe 'a multi page pdf file' do
-      include_examples :behave_like_pdf, file: '2_pages.pdf', page_count: 2
-    end
-
-    describe 'a multi page pdf file with content' do
-      include_examples :behave_like_pdf, file: '10_pages.pdf', page_count: 10
+      include_examples :behave_like_pdf, file: '1_page.pdf'
     end
   end
 end


### PR DESCRIPTION
As discussed today. This PR resets the PDF parser to the basics (in short: removes the dirty page count reader).