### PR TITLE
#119: Add title/album/artist to FormatParser::Audio object

### DIFF
--- a/lib/audio.rb
+++ b/lib/audio.rb
@@ -4,6 +4,15 @@ module FormatParser
 
     NATURE = :audio
 
+    # Title of the audio
+    attr_accessor :title
+
+    # Album of the audio
+    attr_accessor :album
+
+    # Artist of the audio
+    attr_accessor :artist
+
     # Type of the file (e.g :mp3)
     attr_accessor :format
 

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -81,6 +81,8 @@ class FormatParser::MP3Parser
 
     first_frame = initial_frames.first
 
+    id3tags_hash = blend_id3_tags_into_hash(*tags)
+
     file_info = FormatParser::Audio.new(
       format: :mp3,
       # media_duration_frames is omitted because the frames
@@ -88,7 +90,10 @@ class FormatParser::MP3Parser
       # do not tell anything of substance
       num_audio_channels: first_frame.channels,
       audio_sample_rate_hz: first_frame.sample_rate,
-      intrinsics: blend_id3_tags_into_hash(*tags).merge(id3tags: tags)
+      title: id3tags_hash[:title],
+      album: id3tags_hash[:album],
+      artist: id3tags_hash[:artist],
+      intrinsics: id3tags_hash.merge(id3tags: tags)
     )
 
     if maybe_xing_header

--- a/spec/parsers/mp3_parser_spec.rb
+++ b/spec/parsers/mp3_parser_spec.rb
@@ -11,6 +11,9 @@ describe FormatParser::MP3Parser do
     expect(parsed.format).to eq(:mp3)
     expect(parsed.num_audio_channels).to eq(2)
     expect(parsed.audio_sample_rate_hz).to eq(44100)
+    expect(parsed.title).to eq('')
+    expect(parsed.artist).to eq('')
+    expect(parsed.album).to eq('')
     expect(parsed.intrinsics).not_to be_nil
     expect(parsed.media_duration_seconds).to be_within(0.1).of(0.836)
   end


### PR DESCRIPTION
For [Audio struct](https://github.com/WeTransfer/format_parser/blob/master/lib/audio.rb), it will be handy to have direct access to `title`, `artist` and `album` attributes, while fetching them from `id3tags` results (not from `intrinsics` hash), this way, any changes in `intrinsics` would not affect the value of these three attributes.

Note: I found only `Mp3Parser` is the one setting `title`, `album`, `artist` for an audio (inside the `intrinsics` hash)