### PR TITLE
Hint which parser to apply first using the filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
 - 2.2.0
 - 2.6.2
-- jruby-9.0
+- jruby
 sudo: false
 cache: bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 rvm:
 - 2.2.0
-- 2.3.0
-- 2.4.2
-- 2.5.0
+- 2.6.2
 - jruby-9.0
 sudo: false
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 rvm:
 - 2.2.0
-- 2.6.2
+- 2.4.6
+- 2.5.5
+- 2.6.3
 - jruby
 sudo: false
 cache: bundler

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -257,7 +257,7 @@ module FormatParser
 
 
     # If there is one parser that is more likely to match, place it first
-    if first_match = factories_in_order_of_priority.find {|f| f.respond_to?(:likely_match?) && f.likely_match?(filename_hint) }
+    if first_match = factories_in_order_of_priority.find { |f| f.respond_to?(:likely_match?) && f.likely_match?(filename_hint) }
       factories_in_order_of_priority.delete(first_match)
       factories_in_order_of_priority.unshift(first_match)
     end

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -255,7 +255,6 @@ module FormatParser
       @parser_priorities[parser_factory_a] <=> @parser_priorities[parser_factory_b]
     end
 
-
     # If there is one parser that is more likely to match, place it first
     if first_match = factories_in_order_of_priority.find { |f| f.respond_to?(:likely_match?) && f.likely_match?(filename_hint) }
       factories_in_order_of_priority.delete(first_match)

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -94,6 +94,7 @@ module FormatParser
 
   # Parses the file at the given `path` and returns the results as if it were any IO
   # given to `.parse`. The accepted keyword arguments are the same as the ones for `parse`.
+  # The file path will be used to provide the `filename_hint` to `.parse()`.
   #
   # @param path[String] the path to the file to parse on the local filesystem
   # @param kwargs the keyword arguments to be delegated to `.parse`
@@ -119,10 +120,10 @@ module FormatParser
   #   When using `:first` parsing will stop at the first successful match and other parsers won't run.
   # @param limits_config[ReadLimitsConfig] the configuration object for various read/cache limits. The default
   #   one should be good for most cases.
-  # @param filename_hint[String?] the filename. If provided, the first parsers that will be applied are
-  #   going to be the ones which match this filename extension and are therefore more
-  #   likely to match. This way we can "rearrange" our format popularity list just
-  #   for this file.
+  # @param filename_hint[String?] the filename. If provided, the first parser applied will be the
+  #   one that responds `true` to `likely_match?` with that filename as an argument. This way
+  #   we can optimize the order of application of parsers and start with the one that is more likely
+  #   to match.
   # @return [Array<Result>, Result, nil] either an Array of results, a single parsing result or `nil`if
   #   no useful metadata could be recovered from the file
   def self.parse(io, natures: @parsers_per_nature.keys, formats: @parsers_per_format.keys, results: :first, limits_config: default_limits_config, filename_hint: nil)

--- a/lib/parsers/aiff_parser.rb
+++ b/lib/parsers/aiff_parser.rb
@@ -18,6 +18,10 @@ class FormatParser::AIFFParser
     'ANNO',
   ]
 
+  def self.likely_match?(filename)
+    filename =~ /\.aiff?$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
     form_chunk_type, chunk_size = safe_read(io, 8).unpack('a4N')

--- a/lib/parsers/bmp_parser.rb
+++ b/lib/parsers/bmp_parser.rb
@@ -6,6 +6,10 @@ class FormatParser::BMPParser
   VALID_BMP = 'BM'
   PERMISSIBLE_PIXEL_ARRAY_LOCATIONS = 40..512
 
+  def self.likely_match?(filename)
+    filename =~ /\.bmp$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
 

--- a/lib/parsers/cr2_parser.rb
+++ b/lib/parsers/cr2_parser.rb
@@ -7,6 +7,10 @@ class FormatParser::CR2Parser
   TIFF_HEADER = [0x49, 0x49, 0x2a, 0x00]
   CR2_HEADER  = [0x43, 0x52, 0x02, 0x00]
 
+  def self.likely_match?(filename)
+    filename =~ /\.cr2$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
 

--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -19,6 +19,10 @@ class FormatParser::DPXParser
 
   private_constant :ByteOrderHintIO
 
+  def self.likely_match?(filename)
+    filename =~ /\.dpx$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
     magic = safe_read(io, 4)

--- a/lib/parsers/fdx_parser.rb
+++ b/lib/parsers/fdx_parser.rb
@@ -1,6 +1,10 @@
 class FormatParser::FDXParser
   include FormatParser::IOUtils
 
+  def self.likely_match?(filename)
+    filename =~ /\.fdx$/i
+  end
+
   def call(io)
     return unless xml_check(io)
     file_and_document_type = safe_read(io, 100)

--- a/lib/parsers/flac_parser.rb
+++ b/lib/parsers/flac_parser.rb
@@ -5,8 +5,8 @@ class FormatParser::FLACParser
   MAGIC_BYTE_STRING = 'fLaC'
   BLOCK_HEADER_BYTES = 4
 
-  def bytestring_to_int(s)
-    s.unpack('B*')[0].to_i(2)
+  def self.likely_match?(filename)
+    filename =~ /\.flac$/i
   end
 
   def call(io)
@@ -69,6 +69,10 @@ class FormatParser::FLACParser
         maximum_block_size: maximum_block_size
       }
     )
+  end
+
+  def bytestring_to_int(s)
+    s.unpack('B*')[0].to_i(2)
   end
 
   FormatParser.register_parser self, natures: :audio, formats: :flac

--- a/lib/parsers/gif_parser.rb
+++ b/lib/parsers/gif_parser.rb
@@ -4,6 +4,10 @@ class FormatParser::GIFParser
   HEADERS = ['GIF87a', 'GIF89a'].map(&:b)
   NETSCAPE_AND_AUTHENTICATION_CODE = 'NETSCAPE2.0'
 
+  def self.likely_match?(filename)
+    filename =~ /\.gif$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
     header = safe_read(io, 6)

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -13,6 +13,10 @@ class FormatParser::JPEGParser
   EXIF_MAGIC_STRING = "Exif\0\0".b
   MUST_FIND_NEXT_MARKER_WITHIN_BYTES = 1024
 
+  def self.likely_match?(filename)
+    filename =~ /\.jpe?g$/i
+  end
+
   def call(io)
     @buf = FormatParser::IOConstraint.new(io)
     @width             = nil

--- a/lib/parsers/moov_parser.rb
+++ b/lib/parsers/moov_parser.rb
@@ -11,6 +11,10 @@ class FormatParser::MOOVParser
     'm4a ' => :m4a,
   }
 
+  def self.likely_match?(filename)
+    filename =~ /\.(mov|m4a|ma4|mp4|aac)$/i
+  end
+
   def call(io)
     return unless matches_moov_definition?(io)
 

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -53,6 +53,10 @@ class FormatParser::MP3Parser
     end
   end
 
+  def self.likely_match?(filename)
+    filename =~ /\.mp3$/i
+  end
+
   def call(raw_io)
     io = FormatParser::IOConstraint.new(raw_io)
 

--- a/lib/parsers/ogg_parser.rb
+++ b/lib/parsers/ogg_parser.rb
@@ -6,6 +6,10 @@ class FormatParser::OggParser
   # Maximum size of an Ogg page
   MAX_POSSIBLE_PAGE_SIZE = 65307
 
+  def self.likely_match?(filename)
+    filename =~ /\.ogg$/i
+  end
+
   def call(io)
     # The format consists of chunks of data each called an "Ogg page". Each page
     # begins with the characters, "OggS", to identify the file as Ogg format.

--- a/lib/parsers/pdf_parser.rb
+++ b/lib/parsers/pdf_parser.rb
@@ -9,6 +9,10 @@ class FormatParser::PDFParser
   #
   PDF_MARKER = /%PDF-1\.[0-8]{1}/
 
+  def self.likely_match?(filename)
+    filename =~ /\.(pdf|ai)$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
 

--- a/lib/parsers/png_parser.rb
+++ b/lib/parsers/png_parser.rb
@@ -15,8 +15,8 @@ class FormatParser::PNGParser
     6 => true,
   }
 
-  def chunk_length_and_type(io)
-    safe_read(io, 8).unpack('Na4')
+  def self.likely_match?(filename)
+    filename =~ /\.png$/i
   end
 
   def call(io)
@@ -68,6 +68,10 @@ class FormatParser::PNGParser
       has_multiple_frames: has_animation,
       num_animation_or_video_frames: num_frames,
     )
+  end
+
+  def chunk_length_and_type(io)
+    safe_read(io, 8).unpack('Na4')
   end
 
   # Give it priority 1 since priority 0 is reserved for JPEG, our most popular

--- a/lib/parsers/psd_parser.rb
+++ b/lib/parsers/psd_parser.rb
@@ -3,6 +3,10 @@ class FormatParser::PSDParser
 
   PSD_HEADER = [0x38, 0x42, 0x50, 0x53]
 
+  def self.likely_match?(filename)
+    filename =~ /\.psd$/i # Maybe also PSB at some point
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
     magic_bytes = safe_read(io, 4).unpack('C4')

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -5,6 +5,10 @@ class FormatParser::TIFFParser
   MAGIC_LE = [0x49, 0x49, 0x2A, 0x0].pack('C4')
   MAGIC_BE = [0x4D, 0x4D, 0x0, 0x2A].pack('C4')
 
+  def self.likely_match?(filename)
+    filename =~ /\.tiff?$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
 

--- a/lib/parsers/wav_parser.rb
+++ b/lib/parsers/wav_parser.rb
@@ -1,6 +1,10 @@
 class FormatParser::WAVParser
   include FormatParser::IOUtils
 
+  def self.likely_match?(filename)
+    filename =~ /\.wav$/i
+  end
+
   def call(io)
     # Read the RIFF header. Chunk descriptor should be RIFF, the size should
     # contain the size of the entire file in bytes minus 8 bytes for the

--- a/lib/parsers/zip_parser.rb
+++ b/lib/parsers/zip_parser.rb
@@ -5,6 +5,10 @@ class FormatParser::ZIPParser
   include OfficeFormats
   include FormatParser::IOUtils
 
+  def self.likely_match?(filename)
+    filename =~ /\.(zip|docx|keynote|numbers|pptx|xlsx)$/i
+  end
+
   def call(io)
     io = FormatParser::IOConstraint.new(io)
     safe_read(io, 1) # Ensure the file is not empty

--- a/spec/format_parser_spec.rb
+++ b/spec/format_parser_spec.rb
@@ -139,7 +139,7 @@ describe FormatParser do
 
     it 'passes keyword arguments to parse()' do
       path = fixtures_dir + '/WAV/c_M1F1-Alaw-AFsp.wav'
-      expect(FormatParser).to receive(:parse).with(an_instance_of(File), foo: :bar)
+      expect(FormatParser).to receive(:parse).with(an_instance_of(File), filename_hint: 'c_M1F1-Alaw-AFsp.wav', foo: :bar)
       FormatParser.parse_file_at(path, foo: :bar)
     end
   end
@@ -164,6 +164,14 @@ describe FormatParser do
     it 'omits parsers not matching nature' do
       image_parsers = FormatParser.parsers_for([:image], [:tif, :jpg, :aiff, :mp3])
       expect(image_parsers.length).to eq(2)
+    end
+
+    it 'returns an array with the ZIPParser first if the filename_hint is for a ZIP file' do
+      prioritized_parsers = FormatParser.parsers_for([:archive, :document, :image, :audio], [:tif, :jpg, :zip, :docx, :mp3, :aiff], nil)
+      expect(prioritized_parsers.first).not_to be_kind_of(FormatParser::ZIPParser)
+
+      prioritized_parsers = FormatParser.parsers_for([:archive, :document, :image, :audio], [:tif, :jpg, :zip, :docx, :mp3, :aiff], 'a-file.zip')
+      expect(prioritized_parsers.first).to be_kind_of(FormatParser::ZIPParser)
     end
   end
 

--- a/spec/parsers/zip_parser_spec.rb
+++ b/spec/parsers/zip_parser_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe FormatParser::ZIPParser do
+  it 'provides filename hints' do
+    expect(FormatParser::ZIPParser).to be_likely_match('file.zip')
+    expect(FormatParser::ZIPParser).not_to be_likely_match('file.tif')
+  end
+
   it 'parses a ZIP archive with Zip64 extra fields (due to the number of files)' do
     fixture_path = fixtures_dir + '/ZIP/arch_many_entries.zip'
     fi_io = File.open(fixture_path, 'rb')


### PR DESCRIPTION
In some situations we spend way more time applying parsers because the file is in a less-popular format - for example a WAV file. We spend quite a bit of time going through other parsers - some of which are slow. So before we have matched it as a WAV we have to walk through the JPEG parser, then through the ZIP parser (which is quite eager and slow-ish as well), and only at the end we are going to match it as a WAV file.

However, if we know the filename upfront we can do it smarter and apply the parser that is more likely to match first. Note that we won't be assuming the file is of a certain format just based on the filename - we are merely going to rearrange the order of application of the parsers, to optimise it for this particular file.