### PR TITLE
Make most parsers singletons

### DIFF
--- a/lib/parsers/aiff_parser.rb
+++ b/lib/parsers/aiff_parser.rb
@@ -18,7 +18,7 @@ class FormatParser::AIFFParser
     'ANNO',
   ]
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.aiff?$/i
   end
 
@@ -84,5 +84,5 @@ class FormatParser::AIFFParser
     (sign == '1' ? -1.0 : 1.0) * (fraction.to_f / ((1 << 63) - 1)) * (2**exponent)
   end
 
-  FormatParser.register_parser self, natures: :audio, formats: :aiff
+  FormatParser.register_parser new, natures: :audio, formats: :aiff
 end

--- a/lib/parsers/bmp_parser.rb
+++ b/lib/parsers/bmp_parser.rb
@@ -6,7 +6,7 @@ class FormatParser::BMPParser
   VALID_BMP = 'BM'
   PERMISSIBLE_PIXEL_ARRAY_LOCATIONS = 40..512
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.bmp$/i
   end
 
@@ -44,5 +44,5 @@ class FormatParser::BMPParser
     )
   end
 
-  FormatParser.register_parser self, natures: :image, formats: :bmp
+  FormatParser.register_parser new, natures: :image, formats: :bmp
 end

--- a/lib/parsers/cr2_parser.rb
+++ b/lib/parsers/cr2_parser.rb
@@ -7,7 +7,7 @@ class FormatParser::CR2Parser
   TIFF_HEADER = [0x49, 0x49, 0x2a, 0x00]
   CR2_HEADER  = [0x43, 0x52, 0x02, 0x00]
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.cr2$/i
   end
 
@@ -44,5 +44,5 @@ class FormatParser::CR2Parser
     nil
   end
 
-  FormatParser.register_parser self, natures: :image, formats: :cr2
+  FormatParser.register_parser new, natures: :image, formats: :cr2
 end

--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -19,7 +19,7 @@ class FormatParser::DPXParser
 
   private_constant :ByteOrderHintIO
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.dpx$/i
   end
 
@@ -59,5 +59,5 @@ class FormatParser::DPXParser
     )
   end
 
-  FormatParser.register_parser self, natures: :image, formats: :dpx
+  FormatParser.register_parser new, natures: :image, formats: :dpx
 end

--- a/lib/parsers/fdx_parser.rb
+++ b/lib/parsers/fdx_parser.rb
@@ -1,7 +1,7 @@
 class FormatParser::FDXParser
   include FormatParser::IOUtils
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.fdx$/i
   end
 
@@ -30,5 +30,5 @@ class FormatParser::FDXParser
     end
   end
 
-  FormatParser.register_parser self, natures: :document, formats: :fdx
+  FormatParser.register_parser new, natures: :document, formats: :fdx
 end

--- a/lib/parsers/flac_parser.rb
+++ b/lib/parsers/flac_parser.rb
@@ -5,7 +5,7 @@ class FormatParser::FLACParser
   MAGIC_BYTE_STRING = 'fLaC'
   BLOCK_HEADER_BYTES = 4
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.flac$/i
   end
 
@@ -75,5 +75,5 @@ class FormatParser::FLACParser
     s.unpack('B*')[0].to_i(2)
   end
 
-  FormatParser.register_parser self, natures: :audio, formats: :flac
+  FormatParser.register_parser new, natures: :audio, formats: :flac
 end

--- a/lib/parsers/gif_parser.rb
+++ b/lib/parsers/gif_parser.rb
@@ -4,7 +4,7 @@ class FormatParser::GIFParser
   HEADERS = ['GIF87a', 'GIF89a'].map(&:b)
   NETSCAPE_AND_AUTHENTICATION_CODE = 'NETSCAPE2.0'
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.gif$/i
   end
 
@@ -48,5 +48,5 @@ class FormatParser::GIFParser
     )
   end
 
-  FormatParser.register_parser self, natures: :image, formats: :gif, priority: 0
+  FormatParser.register_parser new, natures: :image, formats: :gif, priority: 0
 end

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -17,6 +17,10 @@ class FormatParser::JPEGParser
     filename =~ /\.jpe?g$/i
   end
 
+  def self.call(io)
+    new.call(io)
+  end
+
   def call(io)
     @buf = FormatParser::IOConstraint.new(io)
     @width             = nil

--- a/lib/parsers/moov_parser.rb
+++ b/lib/parsers/moov_parser.rb
@@ -11,7 +11,7 @@ class FormatParser::MOOVParser
     'm4a ' => :m4a,
   }
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.(mov|m4a|ma4|mp4|aac)$/i
   end
 
@@ -87,5 +87,5 @@ class FormatParser::MOOVParser
     maybe_atom_size >= minimum_ftyp_atom_size && maybe_ftyp_atom_signature == 'ftyp'
   end
 
-  FormatParser.register_parser self, natures: :video, formats: FTYP_MAP.values, priority: 1
+  FormatParser.register_parser new, natures: :video, formats: FTYP_MAP.values, priority: 1
 end

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -53,7 +53,7 @@ class FormatParser::MP3Parser
     end
   end
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.mp3$/i
   end
 
@@ -297,5 +297,5 @@ class FormatParser::MP3Parser
     attrs
   end
 
-  FormatParser.register_parser self, natures: :audio, formats: :mp3, priority: 99
+  FormatParser.register_parser new, natures: :audio, formats: :mp3, priority: 99
 end

--- a/lib/parsers/ogg_parser.rb
+++ b/lib/parsers/ogg_parser.rb
@@ -6,7 +6,7 @@ class FormatParser::OggParser
   # Maximum size of an Ogg page
   MAX_POSSIBLE_PAGE_SIZE = 65307
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.ogg$/i
   end
 
@@ -218,5 +218,5 @@ class FormatParser::OggParser
     0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4
   ].freeze
 
-  FormatParser.register_parser self, natures: :audio, formats: :ogg
+  FormatParser.register_parser new, natures: :audio, formats: :ogg
 end

--- a/lib/parsers/pdf_parser.rb
+++ b/lib/parsers/pdf_parser.rb
@@ -9,7 +9,7 @@ class FormatParser::PDFParser
   #
   PDF_MARKER = /%PDF-1\.[0-8]{1}/
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.(pdf|ai)$/i
   end
 
@@ -21,5 +21,5 @@ class FormatParser::PDFParser
     FormatParser::Document.new(format: :pdf)
   end
 
-  FormatParser.register_parser self, natures: :document, formats: :pdf, priority: 1
+  FormatParser.register_parser new, natures: :document, formats: :pdf, priority: 1
 end

--- a/lib/parsers/png_parser.rb
+++ b/lib/parsers/png_parser.rb
@@ -15,7 +15,7 @@ class FormatParser::PNGParser
     6 => true,
   }
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.png$/i
   end
 
@@ -75,5 +75,5 @@ class FormatParser::PNGParser
   end
 
   # Give it priority 1 since priority 0 is reserved for JPEG, our most popular
-  FormatParser.register_parser self, natures: :image, formats: :png, priority: 1
+  FormatParser.register_parser new, natures: :image, formats: :png, priority: 1
 end

--- a/lib/parsers/psd_parser.rb
+++ b/lib/parsers/psd_parser.rb
@@ -3,7 +3,7 @@ class FormatParser::PSDParser
 
   PSD_HEADER = [0x38, 0x42, 0x50, 0x53]
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.psd$/i # Maybe also PSB at some point
   end
 
@@ -23,5 +23,5 @@ class FormatParser::PSDParser
     )
   end
 
-  FormatParser.register_parser self, natures: :image, formats: :psd
+  FormatParser.register_parser new, natures: :image, formats: :psd
 end

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -5,7 +5,7 @@ class FormatParser::TIFFParser
   MAGIC_LE = [0x49, 0x49, 0x2A, 0x0].pack('C4')
   MAGIC_BE = [0x4D, 0x4D, 0x0, 0x2A].pack('C4')
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.tiff?$/i
   end
 
@@ -43,5 +43,5 @@ class FormatParser::TIFFParser
     safe_read(io, 2) == 'CR'
   end
 
-  FormatParser.register_parser self, natures: :image, formats: :tif
+  FormatParser.register_parser new, natures: :image, formats: :tif
 end

--- a/lib/parsers/wav_parser.rb
+++ b/lib/parsers/wav_parser.rb
@@ -1,7 +1,7 @@
 class FormatParser::WAVParser
   include FormatParser::IOUtils
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.wav$/i
   end
 
@@ -99,5 +99,5 @@ class FormatParser::WAVParser
     )
   end
 
-  FormatParser.register_parser self, natures: :audio, formats: :wav
+  FormatParser.register_parser new, natures: :audio, formats: :wav
 end

--- a/lib/parsers/zip_parser.rb
+++ b/lib/parsers/zip_parser.rb
@@ -5,7 +5,7 @@ class FormatParser::ZIPParser
   include OfficeFormats
   include FormatParser::IOUtils
 
-  def self.likely_match?(filename)
+  def likely_match?(filename)
     filename =~ /\.(zip|docx|keynote|numbers|pptx|xlsx)$/i
   end
 
@@ -58,5 +58,5 @@ class FormatParser::ZIPParser
     end
   end
 
-  FormatParser.register_parser self, natures: [:archive, :document], formats: :zip, priority: 2
+  FormatParser.register_parser new, natures: [:archive, :document], formats: :zip, priority: 2
 end

--- a/spec/parsers/zip_parser_spec.rb
+++ b/spec/parsers/zip_parser_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe FormatParser::ZIPParser do
   it 'provides filename hints' do
-    expect(FormatParser::ZIPParser).to be_likely_match('file.zip')
-    expect(FormatParser::ZIPParser).not_to be_likely_match('file.tif')
+    expect(subject).to be_likely_match('file.zip')
+    expect(subject).not_to be_likely_match('file.tif')
   end
 
   it 'parses a ZIP archive with Zip64 extra fields (due to the number of files)' do


### PR DESCRIPTION
Parsers which do not have internal state can be reused
across multiple threads and invocations, which reduces memory
churn between calls to FormatParser - no new parsers will have to
be instantiated. The only parser that now _is_ stateful (the JPEG parser)
can instantiate itself.