### PR TITLE
Add m4v to be a likely mov match

### DIFF
--- a/lib/parsers/moov_parser.rb
+++ b/lib/parsers/moov_parser.rb
@@ -12,7 +12,7 @@ class FormatParser::MOOVParser
   }
 
   def likely_match?(filename)
-    filename =~ /\.(mov|m4a|ma4|mp4|aac)$/i
+    filename =~ /\.(mov|m4a|ma4|mp4|aac|m4v)$/i
   end
 
   def call(io)

--- a/spec/parsers/moov_parser_spec.rb
+++ b/spec/parsers/moov_parser_spec.rb
@@ -104,4 +104,8 @@ describe FormatParser::MOOVParser do
     expect(result.width_px).to eq(160)
     expect(result.height_px).to eq(90)
   end
+
+  it 'provides filename hints' do
+    expect(subject).to be_likely_match('file.m4v')
+  end
 end


### PR DESCRIPTION
Closes #139 

As m4v is already part of the mov family, it already parses this information successfully. However it's not included in the likely matches. This PR takes care of that.