### PR TITLE
Fix EXIF compatibility with ActiveSupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.20.1
+* Make sure EXIF results work correctly with ActiveSupport JSON encoders
+
 ## 0.20.0
 * Correctly tag the license on Rubygems as MIT (Hippocratic) for easier audit
 

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '0.20.0'
+  VERSION = '0.20.1'
 end

--- a/spec/parsers/exif_parser_spec.rb
+++ b/spec/parsers/exif_parser_spec.rb
@@ -14,6 +14,34 @@ describe FormatParser::EXIFParser do
     end
   end
 
+  describe 'EXIFStack' do
+    it 'supports respond_to? for methods it does not have' do
+      # Peculiar thing: we need to support respond_to?(:to_hash)
+      # for compatibility with ActiveSupport JSON output. When you call as_json
+      # on an object ActiveSupport implements that as_json method and will then
+      # call #as_json on the contained objects as necessary, _or_ call
+      # other methods if it thinks it is necessary.
+      #
+      # Although we _will_ be implementing to_hash specifically
+      # the respond_to_missing must be implemented correctly
+      stack = FormatParser::EXIFParser::EXIFStack.new([{}, {}])
+      expect(stack).not_to respond_to(:no_such_method__at_all)
+    end
+
+    it 'returns a Hash from #to_hash' do
+      first_fake_exif = double(orientation: 1, to_hash: {foo: 123, bar: 675})
+      second_fake_exif = double(orientation: 4, to_hash: {foo: 245})
+
+      stack = FormatParser::EXIFParser::EXIFStack.new([first_fake_exif, second_fake_exif])
+      stack_as_hash = stack.to_hash
+
+      # In this instance we DO need an actual type_check, because #to_hash
+      # is used by default type coercions in Ruby
+      expect(stack_as_hash).to be_kind_of(Hash)
+      expect(stack_as_hash).to eq(foo: 245, bar: 675, orientation: 4)
+    end
+  end
+
   it 'is able to deal with an orientation tag which a tuple value for orientation' do
     path = fixtures_dir + '/EXIF/double_orientation.exif.bin'
     exif_data = File.open(path, 'rb') do |f|


### PR DESCRIPTION
We had a wrong implementation of respond_to_missing?
on our EXIFStack object, which made as_json
and to_json crash in exciting ways.

Fix this by

* Implementing a to_hash directly, so that ActiveSupport can call it
* Implementing respond_to_missing? correctly with 2 args