### PR TITLE
Improve the MPEG parser a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.21.1
+* MPEG: Ensure parsing does not inadvertently return an Integer instead of Result|nil
+* MPEG: Scan further into the MPEG file than previously (scan 32 1KB chunks)
+* MPEG: Ensure the parser does not raise an exception when there is no data to read for scanning beyound the initial header
+
 ## 0.21.0
 * Adds support for MPEG video files
 

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '0.21.0'
+  VERSION = '0.21.1'
 end

--- a/lib/parsers/mpeg_parser.rb
+++ b/lib/parsers/mpeg_parser.rb
@@ -49,6 +49,7 @@ class FormatParser::MPEGParser
         return file_info(horizontal_size, vertical_size, ratio_code, rate_code)
       end
     end
+    nil # otherwise the return value of Integer#times will be returned
   rescue FormatParser::IOUtils::InvalidRead
     nil
   end

--- a/lib/parsers/mpeg_parser.rb
+++ b/lib/parsers/mpeg_parser.rb
@@ -37,8 +37,8 @@ class FormatParser::MPEGParser
   def self.call(io)
     return unless matches_mpeg_header?(io)
 
-    # We are looping though the stream because there can be several sequence headers and some of them are not usefull.
-    # If we detect that the header is not usefull, then we look for the next one for SEEK_FOR_SEQUENCE_HEADER_TIMES_LIMIT
+    # We are looping though the stream because there can be several sequence headers and some of them are not useful.
+    # If we detect that the header is not useful, then we look for the next one for SEEK_FOR_SEQUENCE_HEADER_TIMES_LIMIT
     # If we reach the EOF, then the mpg is likely to be corrupted and we return nil
     SEEK_FOR_SEQUENCE_HEADER_TIMES_LIMIT.times do
       return if fetch_next_sequence_header_code_position(io).nil?

--- a/lib/parsers/mpeg_parser.rb
+++ b/lib/parsers/mpeg_parser.rb
@@ -26,7 +26,7 @@ class FormatParser::MPEGParser
 
   PACK_HEADER_START_CODE = [0x00, 0x00, 0x01, 0xBA].pack('C*')
   SEQUENCE_HEADER_START_CODE = [0xB3].pack('C*')
-  MAX_BLOCK_READS = 16
+  MAX_BLOCK_READS = 32
   BYTES_TO_READ_PER_READ = 1024
 
   def self.likely_match?(filename)

--- a/spec/parsers/mpeg_parser_spec.rb
+++ b/spec/parsers/mpeg_parser_spec.rb
@@ -15,9 +15,18 @@ describe FormatParser::MPEGParser do
   it 'returns a nil if it is necessary to iterate over a very large number of bytes and the requisite sequences are not detected' do
     bytes_buffer = StringIO.new
     bytes_buffer.write([0x00, 0x00, 0x01, 0xBA].pack('C*')) # MPEG header
-    zero_bytes = [0x00].pack("C") * (1024 * 1024 * 5)
+    zero_bytes = [0x00].pack('C') * (1024 * 1024 * 5)
     bytes_buffer.write(zero_bytes)
 
+    bytes_buffer.rewind
+
+    parse_result = described_class.call(bytes_buffer)
+    expect(parse_result).to be_nil
+  end
+
+  it 'returns a nil if the IO only contains the MPEG header bytes at the start and nothing else' do
+    bytes_buffer = StringIO.new
+    bytes_buffer.write([0x00, 0x00, 0x01, 0xBA].pack('C*')) # MPEG header
     bytes_buffer.rewind
 
     parse_result = described_class.call(bytes_buffer)

--- a/spec/parsers/mpeg_parser_spec.rb
+++ b/spec/parsers/mpeg_parser_spec.rb
@@ -12,6 +12,18 @@ describe FormatParser::MPEGParser do
     expect(parse_result.intrinsics[:frame_rate]).to eq('30')
   end
 
+  it 'returns a nil if it is necessary to iterate over a very large number of bytes and the requisite sequences are not detected' do
+    bytes_buffer = StringIO.new
+    bytes_buffer.write([0x00, 0x00, 0x01, 0xBA].pack('C*')) # MPEG header
+    zero_bytes = [0x00].pack("C") * (1024 * 1024 * 5)
+    bytes_buffer.write(zero_bytes)
+
+    bytes_buffer.rewind
+
+    parse_result = described_class.call(bytes_buffer)
+    expect(parse_result).to be_nil
+  end
+
   it 'parses a file with mpeg extension' do
     parse_result = described_class.call(File.open(__dir__ + '/../fixtures/MPG/video2.mpeg', 'rb'))
 


### PR DESCRIPTION
There was a number of failures similar to https://github.com/WeTransfer/nu_backend/issues/783
It turned out that this was because we would, in some cases, return integers where a `nil` was in order.

The specific file in question does parse after those changes but the pixel dimensions are still incorrect so let's tackle that later.