### PR TITLE
Early return when unexpected type passed

### DIFF
--- a/lib/parsers/exif_parser.rb
+++ b/lib/parsers/exif_parser.rb
@@ -168,6 +168,8 @@ module FormatParser::EXIFParser
   EXIFR.logger = Logger.new(nil)
 
   def exif_from_tiff_io(constrained_io)
+    return if constrained_io.nil? || constrained_io.is_a?(Integer)
+
     Measurometer.instrument('format_parser.EXIFParser.exif_from_tiff_io') do
       raw_exif_data = EXIFR::TIFF.new(IOExt.new(constrained_io))
       raw_exif_data ? EXIFResult.new(raw_exif_data) : nil

--- a/spec/parsers/exif_parser_spec.rb
+++ b/spec/parsers/exif_parser_spec.rb
@@ -75,4 +75,14 @@ describe FormatParser::EXIFParser do
       expect(io.read(1)).to eq('e')
     end
   end
+
+  describe '.exif_from_tiff_io' do
+    it 'early returns when io is nil' do
+      expect(FormatParser::EXIFParser.exif_from_tiff_io(nil)).to be_nil
+    end
+
+    it 'early returns when io is an int' do
+      expect(FormatParser::EXIFParser.exif_from_tiff_io(12345)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Nu backend is having a lot of `TypeError`s like this one: https://appsignal.com/wetransfer/sites/5a8411c7e2954e3edb59d0a9/exceptions/incidents/217

It seems that passing nil or an int when an io object is expected, borks the parser unexpectedly. 

EDIT.
Something similar happens [here](https://appsignal.com/wetransfer/sites/5a841275fc940e427d4ccdd1/exceptions/incidents/202) in the zip parser. It seems that it passes the `safe_read` to make sure it's not nil but the subsequent `read` returns empty. Coult it be that it's only 1 byte? 🤔  