### PR TITLE
Add the option stringify_keys to #as_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.22.0
+* Adds option `stringify_keys: true` to #as_json methods (fix #151)
+
 ## 0.21.1
 * MPEG: Ensure parsing does not inadvertently return an Integer instead of Result|nil
 * MPEG: Scan further into the MPEG file than previously (scan 32 1KB chunks)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ img_info = FormatParser.parse(File.open("myimage.jpg", "rb"))
 JSON.pretty_generate(img_info) #=> ...
 ```
 
+To convert the result to a Hash or a structure suitable for JSON serialization
+
+```ruby
+img_info = FormatParser.parse(File.open("myimage.jpg", "rb"))
+img_info.as_json
+
+# it's also possible to convert all keys to string
+img_info.as_json(stringify_keys: true)
+```
+
+
 ## Creating your own parsers
 
 See the [section on writing parsers in CONTRIBUTING.md](CONTRIBUTING.md#so-you-want-to-contribute-a-new-parser)
@@ -188,7 +199,7 @@ Unless specified otherwise in this section the fixture files are MIT licensed an
 
 ## Copyright
 
-Copyright (c) 2019 WeTransfer. 
+Copyright (c) 2020 WeTransfer.
 
 `format_parser` is distributed under the conditions of the [Hippocratic License](https://firstdonoharm.dev/version/1/2/license.html)
   - See LICENSE.txt for further details.

--- a/lib/attributes_json.rb
+++ b/lib/attributes_json.rb
@@ -15,7 +15,12 @@ module FormatParser::AttributesJSON
 
   # Implements a sane default `as_json` for an object
   # that accessors defined
-  def as_json(root: false)
+  #
+  # @param root[Bool] if true, it surrounds the result in a hash with a key
+  #  `format_parser_file_info`
+  # @param stringify_keys[Bool] if true, it transforms all the hash keys to a string.
+  #   The default value is false for backward compatibility
+  def as_json(root: false, stringify_keys: false, **)
     h = {}
     h['nature'] = nature if respond_to?(:nature) # Needed for file info structs
     methods.grep(/\w\=$/).each_with_object(h) do |attr_writer_method_name, h|
@@ -27,6 +32,9 @@ module FormatParser::AttributesJSON
       sanitized_value = _sanitize_json_value(unwrapped_attribute_value)
       h[reader_method_name] = sanitized_value
     end
+
+    h = FormatParser::HashUtils.deep_transform_keys(h, &:to_s) if stringify_keys
+
     if root
       {'format_parser_file_info' => h}
     else

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -5,6 +5,7 @@ require 'measurometer'
 # top-level methods of the library.
 module FormatParser
   require_relative 'format_parser/version'
+  require_relative 'hash_utils'
   require_relative 'attributes_json'
   require_relative 'image'
   require_relative 'audio'

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '0.21.1'
+  VERSION = '0.22.0'
 end

--- a/lib/hash_utils.rb
+++ b/lib/hash_utils.rb
@@ -1,0 +1,19 @@
+# based on https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/hash/keys.rb#L116
+# I chose to copy this method instead of adding activesupport as a dependency
+# because we want to have the least number of dependencies
+module FormatParser
+  class HashUtils
+    def self.deep_transform_keys(object, &block)
+      case object
+      when Hash
+        object.each_with_object({}) do |(key, value), result|
+          result[yield(key)] = deep_transform_keys(value, &block)
+        end
+      when Array
+        object.map { |e| deep_transform_keys(e, &block) }
+      else
+        object
+      end
+    end
+  end
+end

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -47,10 +47,6 @@ class FormatParser::MP3Parser
         h[k] = value if value
       end
     end
-
-    def as_json(*)
-      to_h
-    end
   end
 
   def likely_match?(filename)

--- a/spec/attributes_json_spec.rb
+++ b/spec/attributes_json_spec.rb
@@ -140,4 +140,30 @@ describe FormatParser::AttributesJSON do
       JSON.pretty_generate(object_with_attributes_module)
     }.to raise_error(/structure too deep/)
   end
+
+  it 'converts all hash keys to string when stringify_keys: true' do
+    fixture_path = fixtures_dir + '/ZIP/arch_few_entries.zip'
+    fi_io = File.open(fixture_path, 'rb')
+
+    result = FormatParser::ZIPParser.new.call(fi_io).as_json(stringify_keys: true)
+
+    result['entries'].each do |entry|
+      entry.each do |key, _value|
+        expect(key).to be_a(String)
+      end
+    end
+  end
+
+  it 'does not convert hash keys to string when stringify_keys: false' do
+    fixture_path = fixtures_dir + '/ZIP/arch_few_entries.zip'
+    fi_io = File.open(fixture_path, 'rb')
+
+    result = FormatParser::ZIPParser.new.call(fi_io).as_json
+
+    result['entries'].each do |entry|
+      entry.each do |key, _value|
+        expect(key).to be_a(Symbol)
+      end
+    end
+  end
 end

--- a/spec/hash_utils_spec.rb
+++ b/spec/hash_utils_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe FormatParser::HashUtils do
+  describe '.deep_transform_keys' do
+    it 'transforms all the keys in a hash' do
+      hash = { aa: 1, 'bb' => 2 }
+      result = described_class.deep_transform_keys(hash, &:to_s)
+
+      expect(result).to eq('aa' => 1, 'bb' => 2)
+    end
+
+    it 'transforms all the keys in a array of hashes' do
+      array = [{ aa: 1, bb: 2 }, { cc: 3, dd: [{c: 2, d: 3}] }]
+      result = described_class.deep_transform_keys(array, &:to_s)
+
+      expect(result).to eq(
+        [{'aa' => 1, 'bb' => 2}, {'cc' => 3, 'dd' => [{'c' => 2, 'd' => 3}]}]
+      )
+    end
+
+    it 'transforms all the keys in a hash recursively' do
+      hash = { aa: 1, bb: { cc: 22, dd: 3 } }
+      result = described_class.deep_transform_keys(hash, &:to_s)
+
+      expect(result).to eq('aa' => 1, 'bb' => { 'cc' => 22, 'dd' => 3})
+    end
+
+    it 'does nothing for an non array/hash object' do
+      object = Object.new
+      result = described_class.deep_transform_keys(object, &:to_s)
+
+      expect(result).to eq(object)
+    end
+
+    it 'returns the last value if different keys are transformed into the same one' do
+      hash = { aa: 0, 'bb' => 2, bb: 1 }
+      result = described_class.deep_transform_keys(hash, &:to_s)
+
+      expect(result).to eq('aa' => 0, 'bb' => 1)
+    end
+  end
+end

--- a/spec/parsers/mp3_parser_spec.rb
+++ b/spec/parsers/mp3_parser_spec.rb
@@ -110,4 +110,32 @@ describe FormatParser::MP3Parser do
       subject.call(StringIO.new(''))
     }.to raise_error(FormatParser::IOUtils::InvalidRead)
   end
+
+  describe '#as_json' do
+    it 'converts all hash keys to string when stringify_keys: true' do
+      fpath = fixtures_dir + '/MP3/Cassy.mp3'
+      result = subject.call(File.open(fpath, 'rb')).as_json(stringify_keys: true)
+
+      expect(
+        result['intrinsics'].keys.map(&:class).uniq
+      ).to eq([String])
+
+      expect(
+        result['intrinsics']['id3tags'].map(&:class).uniq
+      ).to eq([ID3Tag::Tag])
+    end
+
+    it 'does not convert the hash keys to string when stringify_keys: false' do
+      fpath = fixtures_dir + '/MP3/Cassy.mp3'
+      result = subject.call(File.open(fpath, 'rb')).as_json
+
+      expect(
+        result['intrinsics'].keys.map(&:class).uniq
+      ).to eq([Symbol])
+
+      expect(
+        result['intrinsics'][:id3tags].map(&:class).uniq
+      ).to eq([ID3Tag::Tag])
+    end
+  end
 end


### PR DESCRIPTION
Hi folks! This is my 1st PR in this project.

If I did something wrong, please tell me!!

## Motivation

fix #151

## Proposal

- Add `HashUtils.deep_transform_keys` copied from the activesupport source code

I chose to not add `activesupport` as a dependency because it is good to have the least number of dependencies!

- Use `HashUtils.deep_transform_keys` to transform all the keys of the hash generated by `as_json` to a String

I chose to add the option `stringify_keys` on `#as_json` for backward compatibility. I also added info about it on README
