### PR TITLE
Dev improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Gemfile.lock
 
 # OSX Files
 .DS_Store
+
+# rspec examples
+spec/examples.txt

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rake', '~> 12'
   spec.add_development_dependency 'simplecov', '~> 0.15'
-  spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'wetransfer_style', '0.5.0'
   spec.add_development_dependency 'parallel_tests'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@ end
 RSpec.configure do |c|
   c.include SpecHelpers
   c.extend SpecHelpers # makes fixtures_dir available for example groups too
+  # https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures
+  c.example_status_persistence_file_path = 'spec/examples.txt'
 end
 
 RSpec.shared_examples 'an IO object compatible with IOConstraint' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'rspec'
 require 'format_parser'
-require 'pry'
 
 module SpecHelpers
   def fixtures_dir


### PR DESCRIPTION
- ~Replaced `pry` by `pry-byebug` for a better debugging, than it's possible to use the commands `step`, `continue`, `up`, `down`, etc.~

- Removed `pry` as a development dependency -> https://github.com/WeTransfer/format_parser/pull/154#discussion_r453323289

- Set up RSpec to use `example_status_persistence_file_path`, so it's possible to run `rspec --only-failures` and `rspec --next-failure` which are pretty cool! (https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures)