### PR TITLE
Use FormatParser with ActiveStorage

### DIFF
--- a/lib/active_storage/blob_analyzer.rb
+++ b/lib/active_storage/blob_analyzer.rb
@@ -1,0 +1,35 @@
+require_relative 'blob_io'
+
+# An analyzer class that can be hooked to ActiveStorage, in order to enable
+# FormatParser to do the blob analysis instead of ActiveStorage builtin-analyzers.
+# Invoked if properly integrated in Rails initializer.
+
+module FormatParser
+  module ActiveStorage
+    class BlobAnalyzer
+      # Format parser is able to handle a lot of format so by default it will accept all files
+      #
+      # @return [Boolean, true] always return true
+      def self.accept?(_blob)
+        true
+      end
+
+      def initialize(blob)
+        @blob = blob
+      end
+
+      # @return [Hash] file metadatas
+      def metadata
+        io = BlobIO.new(@blob)
+        parsed_file = FormatParser.parse(io)
+
+        if parsed_file
+          # We symbolize keys because of existing output hash format of ImageAnalyzer
+          parsed_file.as_json.symbolize_keys
+        else
+          logger.info "Skipping file analysis because FormatParser doesn't support the file"
+        end
+      end
+    end
+  end
+end

--- a/lib/active_storage/blob_io.rb
+++ b/lib/active_storage/blob_io.rb
@@ -1,0 +1,51 @@
+# Acts as a proxy to turn ActiveStorage file into IO object
+
+module FormatParser
+  module ActiveStorage
+    class BlobIO
+      # @param blob[ActiveStorage::Blob] the file with linked service
+      # @return [BlobIO]
+      def initialize(blob)
+        @blob = blob
+        @service = blob.service
+        @pos = 0
+      end
+
+      # Emulates IO#read, but requires the number of bytes to read.
+      # Rely on `ActiveStorage::Service.download_chunk` of each hosting type (local, S3, Azure, etc)
+      #
+      # @param n_bytes[Integer] how many bytes to read
+      # @return [String] the read bytes
+      def read(n_bytes)
+        # HTTP ranges are exclusive.
+        http_range = (@pos..(@pos + n_bytes - 1))
+        body = @service.download_chunk(@blob.key, http_range)
+        @pos += body.bytesize
+        body.force_encoding(Encoding::ASCII_8BIT)
+      end
+
+      # Emulates IO#seek
+      #
+      # @param [Integer] offset size
+      # @return [Integer] always return 0, `seek` only mutates `pos` attribute
+      def seek(offset)
+        @pos = offset
+        0
+      end
+
+      # Emulates IO#size.
+      #
+      # @return [Integer] the size of the blob size from ActiveStorage
+      def size
+        @blob.byte_size
+      end
+
+      # Emulates IO#pos
+      #
+      # @return [Integer] the current offset (in bytes) of the io
+      def pos
+        @pos
+      end
+    end
+  end
+end

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -18,6 +18,7 @@ module FormatParser
   require_relative 'remote_io'
   require_relative 'io_constraint'
   require_relative 'care'
+  require_relative 'active_storage/blob_analyzer'
 
   # Define Measurometer in the internal namespace as well
   # so that we stay compatible for the applications that use it

--- a/spec/active_storage/blob_io_spec.rb
+++ b/spec/active_storage/blob_io_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe FormatParser::ActiveStorage::BlobIO do
+  let(:blob_service) { double }
+  let(:blob) { double(key: 'blob_key', service: blob_service, byte_size: 43000) }
+  let(:io) { described_class.new(blob) }
+  let(:fixture_path) { fixtures_dir + '/test.png' }
+
+  it_behaves_like 'an IO object compatible with IOConstraint'
+
+  describe '#read' do
+    it 'reads io using download_chunk from ActiveStorage#Service' do
+      allow(blob_service).to receive(:download_chunk) { 'a' }
+
+      expect(io.read(1)).to eq('a')
+    end
+
+    it 'updates #pos on read' do
+      allow(blob_service).to receive(:download_chunk) { 'a' }
+
+      expect { io.read(1) }.to change { io.pos }.from(0).to(1)
+    end
+  end
+
+  describe '#seek' do
+    it 'updates @pos' do
+      expect { io.seek(10) }.to change { io.pos }.from(0).to(10)
+    end
+  end
+
+  describe '#size' do
+    it 'returns the size of the blob byte_size' do
+      expect(io.size).to eq(blob.byte_size)
+    end
+  end
+end

--- a/spec/active_storage/rails_app_spec.rb
+++ b/spec/active_storage/rails_app_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+def skip_reason
+  if RUBY_ENGINE == 'jruby'
+    'Skipping because JRuby have randon failing issue'
+  elsif RUBY_VERSION.to_f < 2.5
+    'Skipping because Rails testing script use Rails 6, who does not support Ruby bellow 2.5'
+  else
+    false
+  end
+end
+
+describe 'Rails app with ActiveStorage and format-parser', skip: skip_reason do
+  describe 'local hosting with ActiveStorage disk adapter' do
+    it 'parse local file with format_parser' do
+      clean_env do
+        cmd = 'ruby spec/integration/active_storage/rails_app.rb'
+        cmd_status = ruby_script_runner(cmd)
+        expect(cmd_status[:stdout].last).to match(/1 runs, 3 assertions, 0 failures, 0 errors, 0 skips/)
+        expect(cmd_status[:exitstatus]).to eq(0)
+      end
+    end
+  end
+
+  def ruby_script_runner(cmd)
+    require 'open3'
+    cmd_status = { stdout: [], exitstatus: nil }
+    Open3.popen2(cmd) do |_stdin, stdout, wait_thr|
+      frame_stdout do
+        while line = stdout.gets
+          puts "|  #{line}"
+          cmd_status[:stdout] << line
+        end
+      end
+      cmd_status[:exitstatus] = wait_thr.value.exitstatus
+    end
+    cmd_status
+  end
+
+  def frame_stdout
+    puts
+    puts '-' * 50
+    yield
+    puts '-' * 50
+  end
+
+  def clean_env
+    if Bundler.respond_to?(:with_unbundled_env)
+      Bundler.with_unbundled_env do
+        yield
+      end
+    else
+      Bundler.with_clean_env do
+        yield
+      end
+    end
+  end
+end

--- a/spec/integration/active_storage/rails_app.rb
+++ b/spec/integration/active_storage/rails_app.rb
@@ -1,0 +1,72 @@
+require 'bundler/inline'
+
+gemfile(true) do
+  source 'https://rubygems.org'
+
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  gem 'rails', '6.0.3'
+  gem 'sqlite3'
+  gem 'format_parser', path: './'
+end
+
+require 'active_record/railtie'
+require 'active_storage/engine'
+require 'tmpdir'
+
+class TestApp < Rails::Application
+  config.root = __dir__
+  config.hosts << 'example.org'
+  config.eager_load = false
+  config.session_store :cookie_store, key: 'cookie_store_key'
+  secrets.secret_key_base = 'secret_key_base'
+
+  config.logger = Logger.new('/dev/null')
+
+  config.active_storage.service = :local
+  config.active_storage.service_configurations = {
+    local: {
+      root: Dir.tmpdir,
+      service: 'Disk'
+    }
+  }
+
+  config.active_storage.analyzers.prepend FormatParser::ActiveStorage::BlobAnalyzer
+end
+
+ENV['DATABASE_URL'] = 'sqlite3::memory:'
+
+Rails.application.initialize!
+
+require ActiveStorage::Engine.root.join('db/migrate/20170806125915_create_active_storage_tables.rb').to_s
+
+ActiveRecord::Schema.define do
+  CreateActiveStorageTables.new.change
+
+  create_table :users, force: true
+end
+
+class User < ActiveRecord::Base
+  has_one_attached :profile_picture
+end
+
+require 'minitest/autorun'
+require 'open-uri'
+
+describe User do
+  describe "profile_picture's metadatas" do
+    it 'parse metadatas with format_parser' do
+      user = User.create
+      user.profile_picture.attach(
+        filename: 'cat.png',
+        io: URI.open('https://freesvg.org/img/1416155153.png')
+      )
+
+      user.profile_picture.analyze
+
+      _(user.profile_picture.metadata[:width_px]).must_equal 500
+      _(user.profile_picture.metadata[:height_px]).must_equal 296
+      _(user.profile_picture.metadata[:color_mode]).must_equal 'rgba'
+    end
+  end
+end


### PR DESCRIPTION
This is heavily inspired by the good job made on #126. 

Few questions I have:
1) Do we want to wrap ActiveStorage errors? Like `ActiveStorage::FileNotFoundError`? 
2) Did I properly handle `BlobIO#size` and `@pos.bytesize`?
3) Different behavior with a `io.read(NEGATIVE_INT)`. Local storage returns `""`, S3 returns all the file. I am wondering in which case we could have a negative `n_bytes` to read?
4) Inspired by https://github.com/shrinerb/shrine/commit/8d92a9fc2ab6d742f1a022af2dc65fb11dbb0408, I choose Minio for S3 interaction. This add a lot of code but also simplify local development. https://shrinerb.com/docs/testing#minio

As mentioned in a previous comment by @julik 
> There are also cases with "reading past the end" of the remote resource that need to be covered etc.

Is this you are speaking about ?

```
2.7.1 :001 > io = BlobIO.new(@blob)
2.7.1 :002 > io.size
 => 46130
2.7.1 :003 > io.seek(100_000)
 => 0
2.7.1 :004 > io.read(100)
Traceback (most recent call last):
       16: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/activestorage-6.0.3/lib/active_storage/service.rb:126:in `instrument'
       15: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/activesupport-6.0.3/lib/active_support/notifications.rb:182:in `instrument'
       14: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/activestorage-6.0.3/lib/active_storage/service/s3_service.rb:43:in `block in download_chunk'
       13: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-s3-1.78.0/lib/aws-sdk-s3/object.rb:808:in `get'
       12: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-s3-1.78.0/lib/aws-sdk-s3/client.rb:4666:in `get_object'
       11: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/seahorse/client/request.rb:72:in `send_request'
       10: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/seahorse/client/plugins/response_target.rb:24:in `call'
        9: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/aws-sdk-core/plugins/response_paging.rb:12:in `call'
        8: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/seahorse/client/plugins/request_callback.rb:71:in `call'
        7: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/aws-sdk-core/plugins/param_converter.rb:26:in `call'
        6: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/aws-sdk-core/plugins/idempotency_token.rb:19:in `call'
        5: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:22:in `call'
        4: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-s3-1.78.0/lib/aws-sdk-s3/plugins/accelerate.rb:47:in `call'
        3: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-s3-1.78.0/lib/aws-sdk-s3/plugins/dualstack.rb:30:in `call'
        2: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-s3-1.78.0/lib/aws-sdk-s3/plugins/sse_cpk.rb:24:in `call'
        1: from /Users/bti/.rvm/gems/ruby-2.7.1/gems/aws-sdk-core-3.104.4/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call'
Aws::S3::Errors::InvalidRange (The requested range is not satisfiable)
```

I am wondering what we want to manage here? Wrapping the error?


Close: #93 