### PR TITLE
Update gem exifr to 1.3.7 (fix #157)

### DIFF
--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'ks', '~> 0.0'
-  spec.add_dependency 'exifr', '~> 1', '>= 1.3.4'
+  spec.add_dependency 'exifr', '~> 1', '>= 1.3.7'
   spec.add_dependency 'id3tag', '~> 0.13'
   spec.add_dependency 'faraday', '~> 0.13'
   spec.add_dependency 'measurometer', '~> 1'


### PR DESCRIPTION
fix #157 

related to https://github.com/remvee/exifr/pull/66

Before this update:
```bash
$ exe/format_parser_inspect broken_thumbnails.jpg
Traceback (most recent call last):
	30: from exe/format_parser_inspect:22:in `<main>'
	29: from exe/format_parser_inspect:22:in `map'
	28: from exe/format_parser_inspect:24:in `block in <main>'
	27: from exe/format_parser_inspect:24:in `public_send'
	26: from /Users/fabioperrella/projects/format_parser/lib/format_parser.rb:105:in `parse_file_at'
	25: from /Users/fabioperrella/projects/format_parser/lib/format_parser.rb:105:in `open'
	24: from /Users/fabioperrella/projects/format_parser/lib/format_parser.rb:106:in `block in parse_file_at'
	23: from /Users/fabioperrella/projects/format_parser/lib/format_parser.rb:174:in `parse'
...
```

After this update:
```bash
$ exe/format_parser_inspect broken_thumbnails.jpg
[
  {
    "source_path_or_url": "broken_thumbnails.jpg",
    "options": {
      "results": "first"
    },
    "result": {
      "nature": "image",
      "format": "jpg",
      "width_px": 1600,
      "height_px": 1200,
      "display_width_px": 1600,
      "display_height_px": 1200,
      "has_multiple_frames": null,
      "orientation": "top_left",
      "has_transparency": null,
      "color_mode": null,
...
```