### PR TITLE
Remove unknown v2.67 from ID3V2_TAG_VERSIONS

### DIFF
--- a/lib/parsers/mp3_parser/id3_extraction.rb
+++ b/lib/parsers/mp3_parser/id3_extraction.rb
@@ -1,6 +1,6 @@
 module FormatParser::MP3Parser::ID3Extraction
   ID3V1_TAG_SIZE_BYTES = 128
-  ID3V2_TAG_VERSIONS = ["\x43\x00".b, "\x03\x00".b, "\x02\x00".b]
+  ID3V2_TAG_VERSIONS = ["\x03\x00".b, "\x02\x00".b]
   MAX_SIZE_FOR_ID3V2 = 1 * 1024 * 1024
 
   extend FormatParser::IOUtils

--- a/spec/parsers/mp3_parser_spec.rb
+++ b/spec/parsers/mp3_parser_spec.rb
@@ -73,7 +73,7 @@ describe FormatParser::MP3Parser do
 
     large_syncsfe_size = [ID3Tag::SynchsafeInteger.encode(more_bytes_than_permitted)].pack('N')
     prepped = StringIO.new(
-      'ID3' + "\x43\x00".b + "\x00".b + large_syncsfe_size + gunk
+      'ID3' + "\x03\x00".b + "\x00".b + large_syncsfe_size + gunk
     )
 
     expect(ID3Tag).not_to receive(:read)


### PR DESCRIPTION
from https://github.com/WeTransfer/format_parser/pull/169#discussion_r495108090

In MP3Parser, we found out that ID3 v2.4.x is not accepted, but it accepts the version 2.67 which does not exist.

We think this version can be removed.