### PR TITLE
Update gem exifr to 1.3.8 to fix a bug

### DIFF
--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'ks', '~> 0.0'
-  spec.add_dependency 'exifr', '~> 1', '>= 1.3.7'
+  spec.add_dependency 'exifr', '~> 1', '>= 1.3.8'
   spec.add_dependency 'id3tag', '~> 0.14'
   spec.add_dependency 'faraday', '~> 0.13'
   spec.add_dependency 'measurometer', '~> 1'


### PR DESCRIPTION
It raised `undefined method '<' for nil:NilClass` with exifr 1.3.7 for some files

From exifr's changelog:

```
EXIF Reader 1.3.8
* bug fix; "Failure to read truncated EXIF/TIFF IFD entry"; thanks Chris Gunther
```