### PR TITLE
Parse dpx files correctly to avoid FloatDomainError

### DIFF
--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -35,18 +35,23 @@ class FormatParser::DPXParser
     w = dpx_structure.fetch(:image).fetch(:pixels_per_line)
     h = dpx_structure.fetch(:image).fetch(:lines_per_element)
 
-    pixel_aspect_w = dpx_structure.fetch(:orientation).fetch(:horizontal_pixel_aspect)
-    pixel_aspect_h = dpx_structure.fetch(:orientation).fetch(:vertical_pixel_aspect)
-    pixel_aspect = pixel_aspect_w / pixel_aspect_h.to_f
-
-    image_aspect = w / h.to_f * pixel_aspect
-
     display_w = w
     display_h = h
-    if image_aspect > 1
-      display_h = (display_w / image_aspect).round
-    else
-      display_w = (display_h * image_aspect).round
+
+    pixel_aspect_w = dpx_structure.fetch(:orientation).fetch(:horizontal_pixel_aspect)
+    pixel_aspect_h = dpx_structure.fetch(:orientation).fetch(:vertical_pixel_aspect)
+
+    # Find display height and width based on aspect only if the file structure has pixel aspects
+    if pixel_aspect_h != 0 && pixel_aspect_w != 0
+      pixel_aspect = pixel_aspect_w / pixel_aspect_h.to_f
+
+      image_aspect = w / h.to_f * pixel_aspect
+
+      if image_aspect > 1
+        display_h = (display_w / image_aspect).round
+      else
+        display_w = (display_h * image_aspect).round
+      end
     end
 
     FormatParser::Image.new(


### PR DESCRIPTION
For certain dpx format images, in the structure, horizontal_pixel_aspect and vertical_pixel_aspect are zero in the orientation. Since we calculate the pixel_aspect from these values, which in turn is used to determine the display_width_px and display_height_px, the value of pixel_aspect comes up to NaN. This later results in a FloatDomainError

As per my understanding, we should only find the display_width_px and display_height_px when the above values are non-zero, else default these to the width_px and height_px

**Error** NaN
/app/vendor/bundle/ruby/2.7.0/gems/format_parser-0.22.1/lib/parsers/dpx_parser.rb:49 round
/app/vendor/bundle/ruby/2.7.0/gems/format_parser-0.22.1/lib/parsers/dpx_parser.rb:49 call
/app/vendor/bundle/ruby/2.7.0/gems/format_parser-0.22.1/lib/format_parser.rb:202 block in execute_parser_and_capture_expected_exceptions
