### PR TITLE
Fix some flaky tests sorting the parsers by name also

### DIFF
--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -62,7 +62,9 @@ module FormatParser
         @parsers_per_format[provided_format] << callable_parser
       end
       @parser_priorities ||= {}
+      @parser_order_of_registration ||= []
       @parser_priorities[callable_parser] = priority
+      @parser_order_of_registration << callable_parser
     end
   end
 
@@ -264,9 +266,9 @@ module FormatParser
         # results in different environments, which can be hard to understand why.
         # There is also no guarantee in the order that the elements are added in
         # @@parser_priorities
-        # So, to have always the same order, we sort by the class name when the
-        # priorities are the same.
-        parser_a.class.name <=> parser_b.class.name
+        # So, to have always the same order, we sort by the order that the parsers
+        # were registered if the priorities are the same.
+        @parser_order_of_registration.index(parser_a) <=> @parser_order_of_registration.index(parser_b)
       end
     end
 

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -62,9 +62,9 @@ module FormatParser
         @parsers_per_format[provided_format] << callable_parser
       end
       @parser_priorities ||= {}
-      @parser_order_of_registration ||= []
+      @parser_registration_order ||= []
       @parser_priorities[callable_parser] = priority
-      @parser_order_of_registration << callable_parser
+      @parser_registration_order << callable_parser
     end
   end
 
@@ -268,7 +268,7 @@ module FormatParser
         # @@parser_priorities
         # So, to have always the same order, we sort by the order that the parsers
         # were registered if the priorities are the same.
-        @parser_order_of_registration.index(parser_a) <=> @parser_order_of_registration.index(parser_b)
+        @parser_registration_order.index(parser_a) <=> @parser_registration_order.index(parser_b)
       end
     end
 

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -258,6 +258,14 @@ module FormatParser
       if @parser_priorities[parser_a] != @parser_priorities[parser_b]
         @parser_priorities[parser_a] <=> @parser_priorities[parser_b]
       else
+        # Some parsers have the same priority and we want them to be always sorted
+        # in the same way, to not change the result of FormatParser.parse(results: :first).
+        # When this changes, it can generate flaky tests or event different
+        # results in different environments, which can be hard to understand why.
+        # There is also no guarantee in the order that the elements are added in
+        # @@parser_priorities
+        # So, to have always the same order, we sort by the class name when the
+        # priorities are the same.
         parser_a.class.name <=> parser_b.class.name
       end
     end

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -49,8 +49,8 @@ module FormatParser
     parser_provided_formats = Array(formats)
     parser_provided_natures = Array(natures)
     PARSER_MUX.synchronize do
-      @parsers ||= Set.new
-      @parsers << callable_parser
+      @parsers ||= []
+      @parsers << callable_parser unless @parsers.include?(callable_parser)
       @parsers_per_nature ||= {}
       parser_provided_natures.each do |provided_nature|
         @parsers_per_nature[provided_nature] ||= Set.new
@@ -62,9 +62,7 @@ module FormatParser
         @parsers_per_format[provided_format] << callable_parser
       end
       @parser_priorities ||= {}
-      @parser_registration_order ||= []
       @parser_priorities[callable_parser] = priority
-      @parser_registration_order << callable_parser
     end
   end
 
@@ -268,7 +266,7 @@ module FormatParser
         # @@parser_priorities
         # So, to have always the same order, we sort by the order that the parsers
         # were registered if the priorities are the same.
-        @parser_registration_order.index(parser_a) <=> @parser_registration_order.index(parser_b)
+        @parsers.index(parser_a) <=> @parsers.index(parser_b)
       end
     end
 

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -49,6 +49,8 @@ module FormatParser
     parser_provided_formats = Array(formats)
     parser_provided_natures = Array(natures)
     PARSER_MUX.synchronize do
+      # It can't be a Set because the method `parsers_for` depends on the order
+      # that the parsers were added.
       @parsers ||= []
       @parsers << callable_parser unless @parsers.include?(callable_parser)
       @parsers_per_nature ||= {}

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -255,7 +255,11 @@ module FormatParser
     # Order the parsers according to their priority value. The ones having a lower
     # value will sort higher and will be applied sooner
     parsers_in_order_of_priority = parsers.to_a.sort do |parser_a, parser_b|
-      @parser_priorities[parser_a] <=> @parser_priorities[parser_b]
+      if @parser_priorities[parser_a] != @parser_priorities[parser_b]
+        @parser_priorities[parser_a] <=> @parser_priorities[parser_b]
+      else
+        parser_a.class.name <=> parser_b.class.name
+      end
     end
 
     # If there is one parser that is more likely to match, place it first

--- a/spec/format_parser_spec.rb
+++ b/spec/format_parser_spec.rb
@@ -180,17 +180,17 @@ describe FormatParser do
         [:cr2, :dpx, :fdx, :flac, :gif, :jpg, :mov, :mp4, :m4a, :mp3, :mpg, :mpeg, :ogg, :png, :tif, :wav]
       )
 
-      expect(parsers.map{ |parser| parser.class.name }).to eq([
-        "Class",
-        "FormatParser::GIFParser",
-        "FormatParser::PNGParser",
-        "FormatParser::CR2Parser",
-        "FormatParser::DPXParser",
-        "FormatParser::FLACParser",
-        "FormatParser::MP3Parser",
-        "FormatParser::OggParser",
-        "FormatParser::TIFFParser",
-        "FormatParser::WAVParser"
+      expect(parsers.map { |parser| parser.class.name }).to eq([
+        'Class',
+        'FormatParser::GIFParser',
+        'FormatParser::PNGParser',
+        'FormatParser::CR2Parser',
+        'FormatParser::DPXParser',
+        'FormatParser::FLACParser',
+        'FormatParser::MP3Parser',
+        'FormatParser::OggParser',
+        'FormatParser::TIFFParser',
+        'FormatParser::WAVParser'
       ])
     end
   end

--- a/spec/format_parser_spec.rb
+++ b/spec/format_parser_spec.rb
@@ -181,8 +181,8 @@ describe FormatParser do
       )
 
       expect(parsers.map { |parser| parser.class.name }).to eq([
-        'Class',
         'FormatParser::GIFParser',
+        'Class',
         'FormatParser::PNGParser',
         'FormatParser::CR2Parser',
         'FormatParser::DPXParser',

--- a/spec/format_parser_spec.rb
+++ b/spec/format_parser_spec.rb
@@ -173,6 +173,26 @@ describe FormatParser do
       prioritized_parsers = FormatParser.parsers_for([:archive, :document, :image, :audio], [:tif, :jpg, :zip, :docx, :mp3, :aiff], 'a-file.zip')
       expect(prioritized_parsers.first).to be_kind_of(FormatParser::ZIPParser)
     end
+
+    it 'sorts the parsers by priority and name' do
+      parsers = FormatParser.parsers_for(
+        [:audio, :image],
+        [:cr2, :dpx, :fdx, :flac, :gif, :jpg, :mov, :mp4, :m4a, :mp3, :mpg, :mpeg, :ogg, :png, :tif, :wav]
+      )
+
+      expect(parsers.map{ |parser| parser.class.name }).to eq([
+        "Class",
+        "FormatParser::GIFParser",
+        "FormatParser::PNGParser",
+        "FormatParser::CR2Parser",
+        "FormatParser::DPXParser",
+        "FormatParser::FLACParser",
+        "FormatParser::MP3Parser",
+        "FormatParser::OggParser",
+        "FormatParser::TIFFParser",
+        "FormatParser::WAVParser"
+      ])
+    end
   end
 
   describe '.register_parser and .deregister_parser' do


### PR DESCRIPTION
fix #183 

## Motivation

Some specs, like [this one](https://github.com/WeTransfer/format_parser/blob/master/spec/format_parser_spec.rb#L121-L129), calls the method `FormatParser.parse` with the option `results: :first`, which is the default value, and checks if the returned parser is the expected one.

In some cases, `FormatParser.parse` recognizes a file with multiple formats, and using `results: :first`, it returns only the first one.

The problem is that the order of these results varies.

In [this method](https://github.com/WeTransfer/format_parser/blob/master/lib/format_parser.rb#L257-L259), there is a logic to sort the parsers by priority, but since there are many with the same priority, the order varies on each execution.

```ruby
parsers_in_order_of_priority = parsers.to_a.sort do |parser_a, parser_b|
  @parser_priorities[parser_a] <=> @parser_priorities[parser_b  
end
```

Because of this, some tests fail as the following example:

```
  1) FormatParser.parse when multiple results are requested without :result=> :all (first result) is expected to eq #<FormatParser::Image:0x00007fa3258d28c0 @format=:dpx, @width_px=1, @height_px=1, @display_width_px=1, @display_height_px=1>
     Failure/Error: it { is_expected.to eq(image) }

       expected: #<FormatParser::Image:0x00007fa3258d28c0 @format=:dpx, @width_px=1, @height_px=1, @display_width_px=1, @display_height_px=1>
            got: #<FormatParser::Audio:0x00007fa321af2488 @format=:mp3, @num_audio_channels=2, @audio_sample_rate_hz=48000, @intrinsics={:id3tags=>[]}, @media_duration_seconds=22.06318816438356>
```

I don't know exactly why the order sometimes is different, but I could prove it by adding this line:

```ruby
# lib/format_parser.rb
def self.parsers_for(desired_natures, desired_formats, filename_hint = nil)
  #...
  parsers_in_order_of_priority.each { |parser| puts parser.class } # <--- this one
  parsers_in_order_of_priority
end
```

When I run on my laptop:
```ruby
irb(main):001:0> file = Tempfile.new
irb(main):002:0> FormatParser.parse(file)
FormatParser::GIFParser
Class
FormatParser::PDFParser
FormatParser::PNGParser
FormatParser::MOOVParser
# ...
```

When I run in production:
```ruby
irb(main):005:0> file = Tempfile.new
=> #<Tempfile:/tmp/20201204-5987-1mu9uer>
irb(main):006:0> FormatParser.parse(file)
FormatParser::GIFParser
Class
FormatParser::PNGParser
FormatParser::PDFParser
FormatParser::MOOVParser
# ...
```

I think it's related to the following MUTEX, which sets a few class variables when registering the parsers:
```ruby
# lib/format_parser.rb
PARSER_MUX = Mutex.new

#...

def self.register_parser(callable_parser, formats:, natures:, priority: LEAST_PRIORITY)
  parser_provided_formats = Array(formats)
  parser_provided_natures = Array(natures)
  PARSER_MUX.synchronize do
    @parsers ||= Set.new
    @parsers << callable_parser
```

I also did a test to see if this depend on the order the files are loaded, but the results are the same in staging and also in my laptop:

```ruby
def self.register_parser(callable_parser, formats:, natures:, priority: LEAST_PRIORITY)
  puts "register: #{callable_parser.class}"
```

## Proposal

This PR changes the way the registered parsers are sorted.

It can help us to fix the flaky tests and also getting different results when running `FormatParser.parse` to get only the first result.