### PR TITLE
Support parsing for m3u and m3u8 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ and [dimensions,](https://github.com/sstephenson/dimensions) borrowing from them
 * DOCX, PPTX, XLSX
 * OGG
 * MPEG, MPG
+* M3U
 
 ...with [more](https://github.com/WeTransfer/format_parser/issues?q=is%3Aissue+is%3Aopen+label%3Aformats) on the way!
 
@@ -193,6 +194,9 @@ Unless specified otherwise in this section the fixture files are MIT licensed an
 - Downloaded from Unspash (and thus freely avaliable) - https://unsplash.com/license and have then been
   manipulated using the [https://github.com/recurser/exif-orientation-examples](exif-orientation-examples)
   script.
+
+### M3U
+- The M3U fixture files were created by one of the project maintainers
 
 ### .key
 - The `keynote_recognized_as_jpeg.key` file was created by the project maintainers

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -19,6 +19,7 @@ module FormatParser
   require_relative 'io_constraint'
   require_relative 'care'
   require_relative 'active_storage/blob_analyzer'
+  require_relative 'm3u'
 
   # Define Measurometer in the internal namespace as well
   # so that we stay compatible for the applications that use it

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -19,7 +19,7 @@ module FormatParser
   require_relative 'io_constraint'
   require_relative 'care'
   require_relative 'active_storage/blob_analyzer'
-  require_relative 'm3u'
+  require_relative 'text'
 
   # Define Measurometer in the internal namespace as well
   # so that we stay compatible for the applications that use it

--- a/lib/m3u.rb
+++ b/lib/m3u.rb
@@ -1,0 +1,22 @@
+module FormatParser
+  class M3U
+    include FormatParser::AttributesJSON
+
+    NATURE = :text
+
+    attr_accessor :format
+    attr_accessor :size
+
+    # Contains all the file content
+    attr_accessor :content
+
+    # Only permits assignments via defined accessors
+    def initialize(**attributes)
+      attributes.map { |(k, v)| public_send("#{k}=", v) }
+    end
+
+    def nature
+      NATURE
+    end
+  end
+end

--- a/lib/parsers/m3u_parser.rb
+++ b/lib/parsers/m3u_parser.rb
@@ -1,0 +1,25 @@
+class FormatParser::M3UParser
+  include FormatParser::IOUtils
+
+  HEADER = '#EXTM3U'
+
+  def likely_match?(filename)
+    filename =~ /\.(m3u|m3u8)$/i
+  end
+
+  def call(io)
+    io = FormatParser::IOConstraint.new(io)
+
+    header = safe_read(io, 7)
+    return unless HEADER.eql?(header)
+
+    file_content = io.read(io.size)
+
+    FormatParser::M3U.new(
+      format: :m3u,
+      size: io.size,
+      content: file_content
+    )
+  end
+  FormatParser.register_parser new, natures: :text, formats: [:m3u, :m3u8]
+end

--- a/lib/parsers/m3u_parser.rb
+++ b/lib/parsers/m3u_parser.rb
@@ -13,12 +13,9 @@ class FormatParser::M3UParser
     header = safe_read(io, 7)
     return unless HEADER.eql?(header)
 
-    file_content = io.read(io.size)
-
-    FormatParser::M3U.new(
+    FormatParser::Text.new(
       format: :m3u,
-      size: io.size,
-      content: file_content
+      size: io.size
     )
   end
   FormatParser.register_parser new, natures: :text, formats: [:m3u, :m3u8]

--- a/lib/parsers/m3u_parser.rb
+++ b/lib/parsers/m3u_parser.rb
@@ -4,7 +4,7 @@ class FormatParser::M3UParser
   HEADER = '#EXTM3U'
 
   def likely_match?(filename)
-    filename =~ /\.(m3u|m3u8)$/i
+    filename =~ /\.m3u8?$/i
   end
 
   def call(io)
@@ -18,5 +18,5 @@ class FormatParser::M3UParser
       size: io.size
     )
   end
-  FormatParser.register_parser new, natures: :text, formats: [:m3u, :m3u8]
+  FormatParser.register_parser new, natures: :text, formats: :m3u
 end

--- a/lib/parsers/m3u_parser.rb
+++ b/lib/parsers/m3u_parser.rb
@@ -14,8 +14,7 @@ class FormatParser::M3UParser
     return unless HEADER.eql?(header)
 
     FormatParser::Text.new(
-      format: :m3u,
-      size: io.size
+      format: :m3u
     )
   end
   FormatParser.register_parser new, natures: :text, formats: :m3u

--- a/lib/text.rb
+++ b/lib/text.rb
@@ -1,14 +1,11 @@
 module FormatParser
-  class M3U
+  class Text
     include FormatParser::AttributesJSON
 
     NATURE = :text
 
     attr_accessor :format
     attr_accessor :size
-
-    # Contains all the file content
-    attr_accessor :content
 
     # Only permits assignments via defined accessors
     def initialize(**attributes)

--- a/lib/text.rb
+++ b/lib/text.rb
@@ -5,7 +5,6 @@ module FormatParser
     NATURE = :text
 
     attr_accessor :format
-    attr_accessor :size
 
     # Only permits assignments via defined accessors
     def initialize(**attributes)

--- a/spec/fixtures/M3U/plain_text.m3u
+++ b/spec/fixtures/M3U/plain_text.m3u
@@ -1,0 +1,2 @@
+C:\My Music\Artist\Year\1.Test.mp3
+C:\My Music\Artist\Year\10.Test.mp3

--- a/spec/fixtures/M3U/sample.m3u
+++ b/spec/fixtures/M3U/sample.m3u
@@ -1,0 +1,5 @@
+#EXTM3U
+#EXTINF:170,Artist - 1
+C:\My Music\Artist\Year\1.Test.mp3
+#EXTINF:3,Artist - 10
+C:\My Music\Artist\Year\10.Test.mp3

--- a/spec/fixtures/M3U/sample.m3u8
+++ b/spec/fixtures/M3U/sample.m3u8
@@ -1,0 +1,5 @@
+#EXTM3U
+#EXTINF:170,Artist - 1
+C:\My Music\Artist\Year\1.Test.mp3
+#EXTINF:3,Artist - 10
+C:\My Music\Artist\Year\10.Test.mp3

--- a/spec/parsers/m3u_parser_spec.rb
+++ b/spec/parsers/m3u_parser_spec.rb
@@ -25,7 +25,6 @@ describe FormatParser::M3UParser do
       expect(parsed_m3u).not_to be_nil
       expect(parsed_m3u.nature).to eq(:text)
       expect(parsed_m3u.format).to eq(:m3u)
-      expect(parsed_m3u.size).to eq(124)
     end
   end
 
@@ -36,7 +35,6 @@ describe FormatParser::M3UParser do
       expect(parsed_m3u).not_to be_nil
       expect(parsed_m3u.nature).to eq(:text)
       expect(parsed_m3u.format).to eq(:m3u)
-      expect(parsed_m3u.size).to eq(124)
     end
   end
 end

--- a/spec/parsers/m3u_parser_spec.rb
+++ b/spec/parsers/m3u_parser_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe FormatParser::M3UParser do
+  let(:parsed_m3u) {
+    subject.call(
+      File.open(
+        Pathname.new(fixtures_dir).join('M3U').join(m3u_file),
+        'rb'
+      )
+    )
+  }
+  let(:file_content) { "\n#EXTINF:170,Artist - 1\nC:\\My Music\\Artist\\Year\\1.Test.mp3\n#EXTINF:3,Artist - 10\nC:\\My Music\\Artist\\Year\\10.Test.mp3\n" }
+
+  describe 'an m3u file with missing header' do
+    let(:m3u_file) { 'plain_text.m3u' }
+
+    it 'does not parse the file successfully' do
+      expect(parsed_m3u).to be_nil
+    end
+  end
+
+  describe 'an m3u file with valid header' do
+    let(:m3u_file) { 'sample.m3u' }
+
+    it 'parses the file successfully' do
+      expect(parsed_m3u).not_to be_nil
+      expect(parsed_m3u.nature).to eq(:text)
+      expect(parsed_m3u.format).to eq(:m3u)
+      expect(parsed_m3u.size).to eq(124)
+      expect(parsed_m3u.content).to eq(file_content)
+    end
+  end
+
+  describe 'an m3u8 file with valid header' do
+    let(:m3u_file) { 'sample.m3u8' }
+
+    it 'parses the file successfully' do
+      expect(parsed_m3u).not_to be_nil
+      expect(parsed_m3u.nature).to eq(:text)
+      expect(parsed_m3u.format).to eq(:m3u)
+      expect(parsed_m3u.size).to eq(124)
+      expect(parsed_m3u.content).to eq(file_content)
+    end
+  end
+end

--- a/spec/parsers/m3u_parser_spec.rb
+++ b/spec/parsers/m3u_parser_spec.rb
@@ -1,15 +1,14 @@
 require 'spec_helper'
 
 describe FormatParser::M3UParser do
-  let(:parsed_m3u) {
+  let(:parsed_m3u) do
     subject.call(
       File.open(
         Pathname.new(fixtures_dir).join('M3U').join(m3u_file),
         'rb'
       )
     )
-  }
-  let(:file_content) { "\n#EXTINF:170,Artist - 1\nC:\\My Music\\Artist\\Year\\1.Test.mp3\n#EXTINF:3,Artist - 10\nC:\\My Music\\Artist\\Year\\10.Test.mp3\n" }
+  end
 
   describe 'an m3u file with missing header' do
     let(:m3u_file) { 'plain_text.m3u' }
@@ -27,7 +26,6 @@ describe FormatParser::M3UParser do
       expect(parsed_m3u.nature).to eq(:text)
       expect(parsed_m3u.format).to eq(:m3u)
       expect(parsed_m3u.size).to eq(124)
-      expect(parsed_m3u.content).to eq(file_content)
     end
   end
 
@@ -39,7 +37,6 @@ describe FormatParser::M3UParser do
       expect(parsed_m3u.nature).to eq(:text)
       expect(parsed_m3u.format).to eq(:m3u)
       expect(parsed_m3u.size).to eq(124)
-      expect(parsed_m3u.content).to eq(file_content)
     end
   end
 end


### PR DESCRIPTION
Closes #186 

While investigating about the m3u files, I found that there can be three types supported. A plain text file, a file with extended directives and file containing hls m3u extensions. 
https://en.wikipedia.org/wiki/M3U
Files which are extracted playlists from media players fall into second and third category. I think that recognising a plain text file as m3u just on the basis of file extension might not be the right thing to do and there is no other way of recognising it as per my understanding.
The second and third category files contain a header #EXTM3U which can be used to recognise them. This is what I am currently doing here. So, this logic will not recognise a plain text m3u file but will be able to recognise an extended m3u or hls m3u extension.

Also, the directives vary for the second and third category and seems complicated to extract the information from these files. I will create another ticket for extracting more information from the files and work on it separately