### PR TITLE
Add MIME types for most popular formats

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -26,6 +26,9 @@ module FormatParser
     # it can be placed here
     attr_accessor :intrinsics
 
+    # The MIME type of the archive
+    attr_accessor :content_type
+
     # Only permits assignments via defined accessors
     def initialize(**attributes)
       attributes.map { |(k, v)| public_send("#{k}=", v) }

--- a/lib/audio.rb
+++ b/lib/audio.rb
@@ -35,6 +35,9 @@ module FormatParser
     # it can be placed here
     attr_accessor :intrinsics
 
+    # The MIME type of the sound file
+    attr_accessor :content_type
+
     # Only permits assignments via defined accessors
     def initialize(**attributes)
       attributes.map { |(k, v)| public_send("#{k}=", v) }

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -7,6 +7,7 @@ module FormatParser
     attr_accessor :format
     attr_accessor :document_type
     attr_accessor :page_count
+    attr_accessor :content_type
 
     # Only permits assignments via defined accessors
     def initialize(**attributes)

--- a/lib/image.rb
+++ b/lib/image.rb
@@ -64,6 +64,9 @@ module FormatParser
     # it can be placed here
     attr_accessor :intrinsics
 
+    # The MIME type of the image file
+    attr_accessor :content_type
+
     # Only permits assignments via defined accessors
     def initialize(**attributes)
       attributes.map { |(k, v)| public_send("#{k}=", v) }

--- a/lib/parsers/aiff_parser.rb
+++ b/lib/parsers/aiff_parser.rb
@@ -1,6 +1,8 @@
 class FormatParser::AIFFParser
   include FormatParser::IOUtils
 
+  AIFF_MIME_TYPE = 'audio/x-aiff'
+
   # Known chunk types we can omit when parsing,
   # grossly lifted from http://www.muratnkonar.com/aiff/
   KNOWN_CHUNKS = [
@@ -70,7 +72,8 @@ class FormatParser::AIFFParser
       num_audio_channels: channels,
       audio_sample_rate_hz: sample_rate.to_i,
       media_duration_frames: sample_frames,
-      media_duration_seconds: duration_in_seconds
+      media_duration_seconds: duration_in_seconds,
+      content_type: AIFF_MIME_TYPE,
     )
   end
 

--- a/lib/parsers/bmp_parser.rb
+++ b/lib/parsers/bmp_parser.rb
@@ -5,6 +5,7 @@ class FormatParser::BMPParser
 
   VALID_BMP = 'BM'
   PERMISSIBLE_PIXEL_ARRAY_LOCATIONS = 26..512
+  BMP_MIME_TYPE = 'image/bmp'
 
   def likely_match?(filename)
     filename =~ /\.bmp$/i
@@ -42,6 +43,7 @@ class FormatParser::BMPParser
       width_px: width,
       height_px: height,
       color_mode: :rgb,
+      content_type: BMP_MIME_TYPE,
       intrinsics: {
         data_order: data_order,
         bits_per_pixel: bit_depth
@@ -63,6 +65,7 @@ class FormatParser::BMPParser
       width_px: width,
       height_px: height.abs,
       color_mode: :rgb,
+      content_type: BMP_MIME_TYPE,
       intrinsics: {
         vertical_resolution: vertical_res,
         horizontal_resolution: horizontal_res,

--- a/lib/parsers/cr2_parser.rb
+++ b/lib/parsers/cr2_parser.rb
@@ -6,6 +6,7 @@ class FormatParser::CR2Parser
 
   TIFF_HEADER = [0x49, 0x49, 0x2a, 0x00]
   CR2_HEADER  = [0x43, 0x52, 0x02, 0x00]
+  CR2_MIME_TYPE = 'image/x-canon-cr2'
 
   def likely_match?(filename)
     filename =~ /\.cr2$/i
@@ -39,6 +40,7 @@ class FormatParser::CR2Parser
       display_height_px: exif_data.rotated? ? w : h,
       orientation: exif_data.orientation_sym,
       intrinsics: {exif: exif_data},
+      content_type: CR2_MIME_TYPE,
     )
   rescue EXIFR::MalformedTIFF
     nil

--- a/lib/parsers/dpx_parser.rb
+++ b/lib/parsers/dpx_parser.rb
@@ -6,6 +6,11 @@ class FormatParser::DPXParser
   BE_MAGIC = 'SDPX'
   LE_MAGIC = BE_MAGIC.reverse
 
+  # There is no official MIME type for DPX, so we have
+  # to invent something useful. We will prefix it with x-
+  # to indicate that it is a vendor subtype
+  DPX_MIME_TYPE = 'image/x-dpx'
+
   class ByteOrderHintIO < SimpleDelegator
     def initialize(io, is_little_endian)
       super(io)
@@ -61,6 +66,7 @@ class FormatParser::DPXParser
       display_width_px: display_w,
       display_height_px: display_h,
       intrinsics: dpx_structure,
+      content_type: DPX_MIME_TYPE,
     )
   end
 

--- a/lib/parsers/flac_parser.rb
+++ b/lib/parsers/flac_parser.rb
@@ -4,6 +4,7 @@ class FormatParser::FLACParser
   MAGIC_BYTES = 4
   MAGIC_BYTE_STRING = 'fLaC'
   BLOCK_HEADER_BYTES = 4
+  FLAC_MIME_TYPE = 'audio/x-flac'
 
   def likely_match?(filename)
     filename =~ /\.flac$/i
@@ -61,6 +62,7 @@ class FormatParser::FLACParser
       audio_sample_rate_hz: sample_rate,
       media_duration_seconds: duration,
       media_duration_frames: total_samples,
+      content_type: FLAC_MIME_TYPE,
       intrinsics: {
         bits_per_sample: bits_per_sample,
         minimum_frame_size: minimum_frame_size,

--- a/lib/parsers/gif_parser.rb
+++ b/lib/parsers/gif_parser.rb
@@ -3,6 +3,7 @@ class FormatParser::GIFParser
 
   HEADERS = ['GIF87a', 'GIF89a'].map(&:b)
   NETSCAPE_AND_AUTHENTICATION_CODE = 'NETSCAPE2.0'
+  GIF_MIME_TYPE = 'image/gif'
 
   def likely_match?(filename)
     filename =~ /\.gif$/i
@@ -45,6 +46,7 @@ class FormatParser::GIFParser
       height_px: h,
       has_multiple_frames: is_animated,
       color_mode: :indexed,
+      content_type: GIF_MIME_TYPE
     )
   end
 

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -12,6 +12,7 @@ class FormatParser::JPEGParser
   APP1_MARKER = 0xE1  # maybe EXIF
   EXIF_MAGIC_STRING = "Exif\0\0".b
   MUST_FIND_NEXT_MARKER_WITHIN_BYTES = 1024
+  JPEG_MIME_TYPE = 'image/jpeg'
 
   def self.likely_match?(filename)
     filename =~ /\.jpe?g$/i
@@ -88,6 +89,7 @@ class FormatParser::JPEGParser
         display_height_px: dh,
         orientation: flat_exif.orientation_sym,
         intrinsics: {exif: flat_exif},
+        content_type: JPEG_MIME_TYPE
       )
 
       return result

--- a/lib/parsers/m3u_parser.rb
+++ b/lib/parsers/m3u_parser.rb
@@ -2,6 +2,7 @@ class FormatParser::M3UParser
   include FormatParser::IOUtils
 
   HEADER = '#EXTM3U'
+  M3U8_MIME_TYPE = 'application/vnd.apple.mpegurl' # https://en.wikipedia.org/wiki/M3U#Internet_media_types
 
   def likely_match?(filename)
     filename =~ /\.m3u8?$/i
@@ -14,7 +15,8 @@ class FormatParser::M3UParser
     return unless HEADER.eql?(header)
 
     FormatParser::Text.new(
-      format: :m3u
+      format: :m3u,
+      content_type: M3U8_MIME_TYPE,
     )
   end
   FormatParser.register_parser new, natures: :text, formats: :m3u

--- a/lib/parsers/moov_parser.rb
+++ b/lib/parsers/moov_parser.rb
@@ -11,6 +11,12 @@ class FormatParser::MOOVParser
     'm4a ' => :m4a,
   }
 
+  # https://tools.ietf.org/html/rfc4337#section-2
+  # There is also video/quicktime which we should be able to capture
+  # here, but there is currently no detection for MOVs versus MP4s
+  MP4_AU_MIME_TYPE = 'audio/mp4'
+  MP4_MIXED_MIME_TYPE = 'video/mp4'
+
   def likely_match?(filename)
     filename =~ /\.(mov|m4a|ma4|mp4|aac|m4v)$/i
   end
@@ -49,10 +55,12 @@ class FormatParser::MOOVParser
     end
 
     # M4A only contains audio, while MP4 and friends can contain video.
-    if format_from_moov_type(file_type) == :m4a
+    fmt = format_from_moov_type(file_type)
+    if fmt == :m4a
       FormatParser::Audio.new(
         format: format_from_moov_type(file_type),
         media_duration_seconds: media_duration_s,
+        content_type: MP4_AU_MIME_TYPE,
         intrinsics: atom_tree,
       )
     else
@@ -61,6 +69,7 @@ class FormatParser::MOOVParser
         width_px: width,
         height_px: height,
         media_duration_seconds: media_duration_s,
+        content_type: MP4_MIXED_MIME_TYPE,
         intrinsics: atom_tree,
       )
     end

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -32,7 +32,7 @@ class FormatParser::MP3Parser
   MAGIC_LE = [0x49, 0x49, 0x2A, 0x0].pack('C4')
   MAGIC_BE = [0x4D, 0x4D, 0x0, 0x2A].pack('C4')
   TIFF_HEADER_BYTES = [MAGIC_LE, MAGIC_BE]
-
+  MP3_MIME_TYPE = 'audio/mpeg'
   # Wraps the Tag object returned by ID3Tag in such
   # a way that a usable JSON representation gets
   # returned
@@ -104,7 +104,8 @@ class FormatParser::MP3Parser
       # do not tell anything of substance
       num_audio_channels: first_frame.channels,
       audio_sample_rate_hz: first_frame.sample_rate,
-      intrinsics: id3tags_hash.merge(id3tags: tags)
+      intrinsics: id3tags_hash.merge(id3tags: tags),
+      content_type: MP3_MIME_TYPE,
     )
 
     extra_file_attirbutes = fetch_extra_attributes_from_id3_tags(id3tags_hash)

--- a/lib/parsers/ogg_parser.rb
+++ b/lib/parsers/ogg_parser.rb
@@ -3,8 +3,8 @@
 class FormatParser::OggParser
   include FormatParser::IOUtils
 
-  # Maximum size of an Ogg page
   MAX_POSSIBLE_PAGE_SIZE = 65307
+  OGG_MIME_TYPE = 'audio/ogg'
 
   def likely_match?(filename)
     filename =~ /\.ogg$/i
@@ -45,7 +45,8 @@ class FormatParser::OggParser
       format: :ogg,
       audio_sample_rate_hz: sample_rate,
       num_audio_channels: channels,
-      media_duration_seconds: duration
+      media_duration_seconds: duration,
+      content_type: OGG_MIME_TYPE,
     )
   end
 

--- a/lib/parsers/pdf_parser.rb
+++ b/lib/parsers/pdf_parser.rb
@@ -1,6 +1,5 @@
 class FormatParser::PDFParser
   include FormatParser::IOUtils
-
   # First 9 bytes of a PDF should be in this format, according to:
   #
   #  https://stackoverflow.com/questions/3108201/detect-if-pdf-file-is-correct-header-pdf
@@ -8,6 +7,7 @@ class FormatParser::PDFParser
   # There are however exceptions, which are left out for now.
   #
   PDF_MARKER = /%PDF-1\.[0-8]{1}/
+  PDF_CONTENT_TYPE = 'application/pdf'
 
   def likely_match?(filename)
     filename =~ /\.(pdf|ai)$/i
@@ -18,7 +18,7 @@ class FormatParser::PDFParser
 
     return unless safe_read(io, 9) =~ PDF_MARKER
 
-    FormatParser::Document.new(format: :pdf)
+    FormatParser::Document.new(format: :pdf, content_type: PDF_CONTENT_TYPE)
   end
 
   FormatParser.register_parser new, natures: :document, formats: :pdf, priority: 1

--- a/lib/parsers/png_parser.rb
+++ b/lib/parsers/png_parser.rb
@@ -14,6 +14,7 @@ class FormatParser::PNGParser
     4 => true, # Grayscale with alpha
     6 => true,
   }
+  PNG_MIME_TYPE = 'image/png'
 
   def likely_match?(filename)
     filename =~ /\.png$/i
@@ -67,6 +68,7 @@ class FormatParser::PNGParser
       color_mode: color_mode,
       has_multiple_frames: has_animation,
       num_animation_or_video_frames: num_frames,
+      content_type: PNG_MIME_TYPE,
     )
   end
 

--- a/lib/parsers/psd_parser.rb
+++ b/lib/parsers/psd_parser.rb
@@ -2,6 +2,7 @@ class FormatParser::PSDParser
   include FormatParser::IOUtils
 
   PSD_HEADER = [0x38, 0x42, 0x50, 0x53]
+  PSD_MIME_TYPE = 'application/x-photoshop'
 
   def likely_match?(filename)
     filename =~ /\.psd$/i # Maybe also PSB at some point
@@ -20,6 +21,7 @@ class FormatParser::PSDParser
       format: :psd,
       width_px: w,
       height_px: h,
+      content_type: PSD_MIME_TYPE,
     )
   end
 

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -34,7 +34,7 @@ class FormatParser::TIFFParser
     format = arw?(exif_data) ? :arw : :tif
     mime_type = arw?(exif_data) ? ARW_MIME_TYPE : TIFF_MIME_TYPE
     FormatParser::Image.new(
-      format: format, 
+      format: format,
       width_px: w,
       height_px: h,
       display_width_px: exif_data.rotated? ? h : w,

--- a/lib/parsers/tiff_parser.rb
+++ b/lib/parsers/tiff_parser.rb
@@ -5,6 +5,8 @@ class FormatParser::TIFFParser
   MAGIC_LE = [0x49, 0x49, 0x2A, 0x0].pack('C4')
   MAGIC_BE = [0x4D, 0x4D, 0x0, 0x2A].pack('C4')
   HEADER_BYTES = [MAGIC_LE, MAGIC_BE]
+  TIFF_MIME_TYPE = 'image/tiff'
+  ARW_MIME_TYPE = 'image/x-sony-arw'
 
   def likely_match?(filename)
     filename =~ /\.tiff?$/i
@@ -14,7 +16,10 @@ class FormatParser::TIFFParser
     io = FormatParser::IOConstraint.new(io)
 
     return unless HEADER_BYTES.include?(safe_read(io, 4))
-    io.seek(io.pos + 2) # Skip over the offset of the IFD, EXIFR will re-read it anyway
+
+    # Skip over the offset of the IFD,
+    # EXIFR will re-read it anyway
+    io.seek(io.pos + 2)
     return if cr2?(io)
 
     # The TIFF scanner in EXIFR is plenty good enough,
@@ -26,14 +31,17 @@ class FormatParser::TIFFParser
     w = exif_data.width || exif_data.pixel_x_dimension
     h = exif_data.height || exif_data.pixel_y_dimension
 
+    format = arw?(exif_data) ? :arw : :tif
+    mime_type = arw?(exif_data) ? ARW_MIME_TYPE : TIFF_MIME_TYPE
     FormatParser::Image.new(
-      format: arw?(exif_data) ? :arw : :tif, # Specify format as arw for Sony ARW format images, else tif
+      format: format, 
       width_px: w,
       height_px: h,
       display_width_px: exif_data.rotated? ? h : w,
       display_height_px: exif_data.rotated? ? w : h,
       orientation: exif_data.orientation_sym,
       intrinsics: {exif: exif_data},
+      content_type: mime_type,
     )
   rescue EXIFR::MalformedTIFF
     nil

--- a/lib/parsers/wav_parser.rb
+++ b/lib/parsers/wav_parser.rb
@@ -1,6 +1,8 @@
 class FormatParser::WAVParser
   include FormatParser::IOUtils
 
+  WAV_MIME_TYPE = 'audio/x-wav'
+
   def likely_match?(filename)
     filename =~ /\.wav$/i
   end
@@ -96,6 +98,7 @@ class FormatParser::WAVParser
       audio_sample_rate_hz: fmt_data[:sample_rate],
       media_duration_frames: sample_frames,
       media_duration_seconds: duration_in_seconds,
+      content_type: WAV_MIME_TYPE,
     )
   end
 

--- a/lib/parsers/zip_parser.rb
+++ b/lib/parsers/zip_parser.rb
@@ -5,6 +5,8 @@ class FormatParser::ZIPParser
   include OfficeFormats
   include FormatParser::IOUtils
 
+  ZIP_MIME_TYPE = 'application/zip'
+
   def likely_match?(filename)
     filename =~ /\.(zip|docx|keynote|numbers|pptx|xlsx)$/i
   end
@@ -25,10 +27,10 @@ class FormatParser::ZIPParser
     end
 
     if office_document?(filenames_set)
-      office_format = office_file_format_from_entry_set(filenames_set)
-      FormatParser::Archive.new(nature: :document, format: office_format, entries: entries_archive)
+      office_format, mime_type = office_file_format_and_mime_type_from_entry_set(filenames_set)
+      FormatParser::Archive.new(nature: :document, format: office_format, entries: entries_archive, content_type: mime_type)
     else
-      FormatParser::Archive.new(nature: :archive,  format: :zip, entries: entries_archive)
+      FormatParser::Archive.new(nature: :archive,  format: :zip, entries: entries_archive, content_type: ZIP_MIME_TYPE)
     end
   rescue FileReader::Error
     # This is not a ZIP, or a broken ZIP.

--- a/lib/parsers/zip_parser/office_formats.rb
+++ b/lib/parsers/zip_parser/office_formats.rb
@@ -37,15 +37,15 @@ module FormatParser::ZIPParser::OfficeFormats
     OFFICE_MARKER_FILES.subset?(filenames_set)
   end
 
-  def office_file_format_from_entry_set(filenames_set)
+  def office_file_format_and_mime_type_from_entry_set(filenames_set)
     if filenames_set.include?('word/document.xml')
-      :docx
+      [:docx, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
     elsif filenames_set.include?('xl/workbook.xml')
-      :xlsx
+      [:xlsx, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']
     elsif filenames_set.include?('ppt/presentation.xml')
-      :pptx
+      [:pptx, 'application/vnd.openxmlformats-officedocument.presentationml.presentation']
     else
-      :unknown
+      [:unknown, 'application/zip']
     end
   end
 end

--- a/lib/text.rb
+++ b/lib/text.rb
@@ -5,6 +5,7 @@ module FormatParser
     NATURE = :text
 
     attr_accessor :format
+    attr_accessor :content_type
 
     # Only permits assignments via defined accessors
     def initialize(**attributes)

--- a/lib/video.rb
+++ b/lib/video.rb
@@ -23,6 +23,9 @@ module FormatParser
     # it can be placed here
     attr_accessor :intrinsics
 
+    # The MIME type of the video
+    attr_accessor :content_type
+
     # Only permits assignments via defined accessors
     def initialize(**attributes)
       attributes.map { |(k, v)| public_send("#{k}=", v) }

--- a/spec/parsers/aiff_parser_spec.rb
+++ b/spec/parsers/aiff_parser_spec.rb
@@ -10,6 +10,7 @@ describe FormatParser::AIFFParser do
     expect(parse_result.num_audio_channels).to eq(2)
     expect(parse_result.audio_sample_rate_hz).to be_within(0.01).of(44100)
     expect(parse_result.media_duration_seconds).to be_within(0.01).of(1.05)
+    expect(parse_result.content_type).to eq('audio/x-aiff')
   end
 
   it 'parses a Logic Pro created AIFF sample file having a COMT chunk before a COMM chunk' do

--- a/spec/parsers/bmp_parser_spec.rb
+++ b/spec/parsers/bmp_parser_spec.rb
@@ -13,6 +13,8 @@ describe FormatParser::BMPParser do
     expect(parsed.width_px).to eq(40)
     expect(parsed.height_px).to eq(27)
 
+    expect(parsed.content_type).to eq('image/bmp')
+
     expect(parsed.intrinsics).not_to be_nil
     expect(parsed.intrinsics[:vertical_resolution]).to eq(2834)
     expect(parsed.intrinsics[:horizontal_resolution]).to eq(2834)
@@ -31,6 +33,8 @@ describe FormatParser::BMPParser do
 
     expect(parsed.width_px).to eq(1920)
     expect(parsed.height_px).to eq(1080)
+
+    expect(parsed.content_type).to eq('image/bmp')
 
     expect(parsed.intrinsics).not_to be_nil
     expect(parsed.intrinsics[:vertical_resolution]).to eq(2835)
@@ -51,6 +55,8 @@ describe FormatParser::BMPParser do
     expect(parsed.width_px).to eq(200)
     expect(parsed.height_px).to eq(200)
 
+    expect(parsed.content_type).to eq('image/bmp')
+
     expect(parsed.intrinsics).not_to be_nil
   end
 
@@ -64,6 +70,7 @@ describe FormatParser::BMPParser do
     expect(parsed.color_mode).to eq(:rgb)
     expect(parsed.width_px).to eq(40)
     expect(parsed.height_px).to eq(27)
+    expect(parsed.content_type).to eq('image/bmp')
     expect(parsed.intrinsics[:bits_per_pixel]).to eq(24)
     expect(parsed.intrinsics[:data_order]).to eq(:normal)
 
@@ -76,6 +83,7 @@ describe FormatParser::BMPParser do
     expect(parsed.color_mode).to eq(:rgb)
     expect(parsed.width_px).to eq(40)
     expect(parsed.height_px).to eq(27)
+    expect(parsed.content_type).to eq('image/bmp')
     expect(parsed.intrinsics[:bits_per_pixel]).to eq(24)
     expect(parsed.intrinsics[:data_order]).to eq(:normal)
   end

--- a/spec/parsers/cr2_parser_spec.rb
+++ b/spec/parsers/cr2_parser_spec.rb
@@ -17,6 +17,7 @@ describe FormatParser::CR2Parser do
         expect(parsed.height_px).to be > 0
 
         expect(parsed.orientation).not_to be_nil
+        expect(parsed.content_type).to eq('image/x-canon-cr2')
       end
     end
   end

--- a/spec/parsers/dpx_parser_spec.rb
+++ b/spec/parsers/dpx_parser_spec.rb
@@ -15,6 +15,7 @@ describe FormatParser::DPXParser do
       expect(parsed.width_px).to be_between(0, 2048)
       expect(parsed.height_px).to be_kind_of(Integer)
       expect(parsed.height_px).to be_between(0, 4000)
+      expect(parsed.content_type).to eq('image/x-dpx')
     end
   end
 

--- a/spec/parsers/flac_parser_spec.rb
+++ b/spec/parsers/flac_parser_spec.rb
@@ -14,6 +14,7 @@ describe FormatParser::FLACParser do
     expect(parsed.intrinsics).not_to be_nil
     expect(parsed.media_duration_frames).to eq(33810)
     expect(parsed.media_duration_seconds).to be_within(0.1).of(0.836)
+    expect(parsed.content_type).to eq('audio/x-flac')
   end
 
   it 'decodes and estimates duration for the 16bit FLAC File' do

--- a/spec/parsers/gif_parser_spec.rb
+++ b/spec/parsers/gif_parser_spec.rb
@@ -17,6 +17,7 @@ describe FormatParser::GIFParser do
 
         expect(parsed.height_px).to be_kind_of(Integer)
         expect(parsed.height_px).to be > 0
+        expect(parsed.content_type).to eq('image/gif')
       end
     end
   end

--- a/spec/parsers/jpeg_parser_spec.rb
+++ b/spec/parsers/jpeg_parser_spec.rb
@@ -14,6 +14,7 @@ describe FormatParser::JPEGParser do
 
         expect(parsed.height_px).to be_kind_of(Integer)
         expect(parsed.height_px).to be > 0
+        expect(parsed.content_type).to eq('image/jpeg')
       end
     end
   end

--- a/spec/parsers/m3u_parser_spec.rb
+++ b/spec/parsers/m3u_parser_spec.rb
@@ -25,6 +25,7 @@ describe FormatParser::M3UParser do
       expect(parsed_m3u).not_to be_nil
       expect(parsed_m3u.nature).to eq(:text)
       expect(parsed_m3u.format).to eq(:m3u)
+      expect(parsed_m3u.content_type).to eq('application/vnd.apple.mpegurl')
     end
   end
 

--- a/spec/parsers/moov_parser_spec.rb
+++ b/spec/parsers/moov_parser_spec.rb
@@ -37,7 +37,7 @@ describe FormatParser::MOOVParser do
       expect(result.nature).to eq(:audio)
       expect(result.media_duration_seconds).to be_kind_of(Float)
       expect(result.media_duration_seconds).to be > 0
-
+      expect(result.content_type).to be_kind_of(String)
       expect(result.intrinsics).not_to be_nil
     end
   end
@@ -52,6 +52,7 @@ describe FormatParser::MOOVParser do
       expect(result.height_px).to be > 0
       expect(result.media_duration_seconds).to be_kind_of(Float)
       expect(result.media_duration_seconds).to be > 0
+      expect(result.content_type).to eq('video/mp4')
 
       expect(result.intrinsics).not_to be_nil
     end
@@ -67,6 +68,7 @@ describe FormatParser::MOOVParser do
       expect(result.height_px).to be > 0
       expect(result.media_duration_seconds).to be_kind_of(Float)
       expect(result.media_duration_seconds).to be > 0
+      expect(result.content_type).to eq('video/mp4')
 
       expect(result.intrinsics).not_to be_nil
     end
@@ -79,6 +81,7 @@ describe FormatParser::MOOVParser do
     expect(result).not_to be_nil
     expect(result.nature).to eq(:audio)
     expect(result.format).to eq(:m4a)
+    expect(result.content_type).to eq('audio/mp4')
   end
 
   it 'parses a MOV file and provides the necessary metadata' do

--- a/spec/parsers/mp3_parser_spec.rb
+++ b/spec/parsers/mp3_parser_spec.rb
@@ -23,6 +23,7 @@ describe FormatParser::MP3Parser do
 
     expect(parsed.nature).to eq(:audio)
     expect(parsed.format).to eq(:mp3)
+    expect(parsed.content_type).to eq('audio/mpeg')
     expect(parsed.num_audio_channels).to eq(2)
     expect(parsed.audio_sample_rate_hz).to eq(48000)
     expect(parsed.intrinsics).not_to be_nil

--- a/spec/parsers/ogg_parser_spec.rb
+++ b/spec/parsers/ogg_parser_spec.rb
@@ -6,6 +6,7 @@ describe FormatParser::OggParser do
 
     expect(parse_result.nature).to eq(:audio)
     expect(parse_result.format).to eq(:ogg)
+    expect(parse_result.content_type).to eq('audio/ogg')
     expect(parse_result.num_audio_channels).to eq(1)
     expect(parse_result.audio_sample_rate_hz).to eq(16000)
     expect(parse_result.media_duration_seconds).to be_within(0.01).of(2973.95)

--- a/spec/parsers/pdf_parser_spec.rb
+++ b/spec/parsers/pdf_parser_spec.rb
@@ -17,6 +17,7 @@ describe FormatParser::PDFParser do
       expect(parsed_pdf).not_to be_nil
       expect(parsed_pdf.nature).to eq(:document)
       expect(parsed_pdf.format).to eq(:pdf)
+      expect(parsed_pdf.content_type).to eq('application/pdf')
     end
   end
 

--- a/spec/parsers/png_parser_spec.rb
+++ b/spec/parsers/png_parser_spec.rb
@@ -15,6 +15,7 @@ describe FormatParser::PNGParser do
 
         expect(parsed.height_px).to be_kind_of(Integer)
         expect(parsed.height_px).to be > 0
+        expect(parsed.content_type).to eq('image/png')
       end
     end
   end

--- a/spec/parsers/psd_parser_spec.rb
+++ b/spec/parsers/psd_parser_spec.rb
@@ -15,6 +15,7 @@ describe FormatParser::PSDParser do
 
         expect(parsed.height_px).to be_kind_of(Integer)
         expect(parsed.height_px).to be > 0
+        expect(parsed.content_type).to eq('application/x-photoshop')
       end
     end
   end

--- a/spec/parsers/tiff_parser_spec.rb
+++ b/spec/parsers/tiff_parser_spec.rb
@@ -59,6 +59,7 @@ describe FormatParser::TIFFParser do
     expect(parsed.width_px).to eq(7952)
     expect(parsed.height_px).to eq(5304)
     expect(parsed.intrinsics[:exif]).not_to be_nil
+    expect(parsed.content_type).to eq('image/x-sony-arw')
   end
 
   describe 'correctly extracts dimensions from various TIFF flavors of the same file' do

--- a/spec/parsers/wav_parser_spec.rb
+++ b/spec/parsers/wav_parser_spec.rb
@@ -9,6 +9,7 @@ describe FormatParser::WAVParser do
 
       expect(parse_result.nature).to eq(:audio)
       expect(parse_result.format).to eq(:wav)
+      expect(parse_result.content_type).to eq('audio/x-wav')
     end
   end
 

--- a/spec/parsers/zip_parser_spec.rb
+++ b/spec/parsers/zip_parser_spec.rb
@@ -59,7 +59,7 @@ describe FormatParser::ZIPParser do
     result = subject.call(fi_io)
     expect(result.nature).to eq(:document)
     expect(result.format).to eq(:docx)
-    expect(result.content_type).to eq("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+    expect(result.content_type).to eq('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
 
     fixture_path = fixtures_dir + '/ZIP/sample-docx.docx'
     fi_io = File.open(fixture_path, 'rb')

--- a/spec/parsers/zip_parser_spec.rb
+++ b/spec/parsers/zip_parser_spec.rb
@@ -14,6 +14,7 @@ describe FormatParser::ZIPParser do
     expect(result).not_to be_nil
 
     expect(result.format).to eq(:zip)
+    expect(result.content_type).to eq('application/zip')
     expect(result.nature).to eq(:archive)
     expect(result.entries.length).to eq(0xFFFF + 1)
 
@@ -58,6 +59,7 @@ describe FormatParser::ZIPParser do
     result = subject.call(fi_io)
     expect(result.nature).to eq(:document)
     expect(result.format).to eq(:docx)
+    expect(result.content_type).to eq("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
 
     fixture_path = fixtures_dir + '/ZIP/sample-docx.docx'
     fi_io = File.open(fixture_path, 'rb')


### PR DESCRIPTION
This info will likely be useful in storm, and indeed FormatParser is the best place to emit it.

Closes #180