### PR TITLE
Change FormatParser.parse_http to follow a redirect

### DIFF
--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'exifr', '~> 1', '>= 1.3.8'
   spec.add_dependency 'id3tag', '~> 0.14'
   spec.add_dependency 'faraday', '~> 0.13'
+  spec.add_dependency 'faraday_middleware', '~> 0.14'
   spec.add_dependency 'measurometer', '~> 1'
 
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -26,6 +26,7 @@ class FormatParser::RemoteIO
   # @param uri[URI, String] the remote URL to obtain
   def initialize(uri)
     require 'faraday'
+    require 'faraday_middleware/response/follow_redirects'
     @uri = uri
     @pos = 0
     @remote_size = false
@@ -78,7 +79,11 @@ class FormatParser::RemoteIO
     # We use a GET and not a HEAD request followed by a GET because
     # S3 does not allow HEAD requests if you only presigned your URL for GETs, so we
     # combine the first GET of a segment and retrieving the size of the resource
-    response = Faraday.get(@uri, nil, range: 'bytes=%d-%d' % [range.begin, range.end])
+    conn = Faraday.new do |faraday|
+      faraday.use FaradayMiddleware::FollowRedirects
+      faraday.adapter Faraday.default_adapter
+    end
+    response = conn.get(@uri, nil, range: 'bytes=%d-%d' % [range.begin, range.end])
 
     case response.status
     when 200, 206

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -81,6 +81,7 @@ class FormatParser::RemoteIO
     # combine the first GET of a segment and retrieving the size of the resource
     conn = Faraday.new do |faraday|
       faraday.use FaradayMiddleware::FollowRedirects
+      # we still need the default adapter, mode details: https://blog.thecodewhisperer.com/permalink/losing-time-to-faraday
       faraday.adapter Faraday.default_adapter
     end
     response = conn.get(@uri, nil, range: 'bytes=%d-%d' % [range.begin, range.end])

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -81,7 +81,7 @@ class FormatParser::RemoteIO
     # combine the first GET of a segment and retrieving the size of the resource
     conn = Faraday.new do |faraday|
       faraday.use FaradayMiddleware::FollowRedirects
-      # we still need the default adapter, mode details: https://blog.thecodewhisperer.com/permalink/losing-time-to-faraday
+      # we still need the default adapter, more details: https://blog.thecodewhisperer.com/permalink/losing-time-to-faraday
       faraday.adapter Faraday.default_adapter
     end
     response = conn.get(@uri, nil, range: 'bytes=%d-%d' % [range.begin, range.end])

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -15,6 +15,10 @@ describe 'Fetching data from HTTP remotes' do
     }
     @server = WEBrick::HTTPServer.new(options)
     @server.mount '/', WEBrick::HTTPServlet::FileHandler, fixtures_dir
+    @server.mount_proc '/redirect' do |req, res|
+      res.status = 302
+      res.header['Location'] = req.path.sub('/redirect', '')
+    end
     trap('INT') { @server.stop }
     @server_thread = Thread.new { @server.start }
   end
@@ -88,6 +92,13 @@ describe 'Fetching data from HTTP remotes' do
         cleaned_remote_fixture_path = remote_fixture_path.gsub(' ', '%20')
         FormatParser.parse_http(cleaned_remote_fixture_path)
       end
+    end
+  end
+
+  context 'when the server respond with a redirect' do
+    it 'follows the redirect' do
+      file_information = FormatParser.parse_http('http://localhost:9399/redirect/TIFF/test.tif')
+      expect(file_information.format).to eq(:tif)
     end
   end
 

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -95,7 +95,7 @@ describe 'Fetching data from HTTP remotes' do
     end
   end
 
-  context 'when the server respond with a redirect' do
+  context 'when the server responds with a redirect' do
     it 'follows the redirect' do
       file_information = FormatParser.parse_http('http://localhost:9399/redirect/TIFF/test.tif')
       expect(file_information.format).to eq(:tif)

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -7,7 +7,9 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {'Content-Range' => '10-109/2577'}, status: 206, body: 'This is the response')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109')
 
     rio.seek(10)
     read_result = rio.read(100)
@@ -18,7 +20,9 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {'Content-Range' => '10-109/2577'}, status: 200, body: 'This is the response')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109')
 
     rio.seek(10)
     read_result = rio.read(100)
@@ -29,7 +33,9 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 403, body: 'Please log in')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199')
 
     rio.seek(100)
     expect { rio.read(100) }.to raise_error(/replied with a 403 and refused/)
@@ -39,7 +45,9 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 416, body: 'You stepped off the ledge of the range')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199')
 
     rio.seek(100)
     expect(rio.read(100)).to be_nil
@@ -49,7 +57,9 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 403, body: 'Please log in')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199')
 
     rio.seek(100)
     # rubocop: disable Lint/AmbiguousBlockAssociation
@@ -60,7 +70,9 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 416, body: 'You jumped off the end of the file maam')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199')
 
     rio.seek(100)
     expect(rio.read(100)).to be_nil
@@ -97,7 +109,9 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 502, body: 'Guru meditation')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199')
 
     rio.seek(100)
     expect { rio.read(100) }.to raise_error(/replied with a 502 and we might want to retry/)
@@ -109,7 +123,9 @@ describe FormatParser::RemoteIO do
     expect(rio.pos).to eq(0)
 
     fake_resp = double(headers: {'Content-Range' => 'bytes 0-0/13'}, status: 206, body: 'a')
-    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=0-0').and_return(fake_resp)
+    faraday_conn = instance_double(Faraday::Connection, get: fake_resp)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=0-0')
     rio.read(1)
 
     expect(rio.pos).to eq(1)

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -7,7 +7,7 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {'Content-Range' => '10-109/2577'}, status: 206, body: 'This is the response')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109').and_return(fake_resp)
 
     rio.seek(10)
     read_result = rio.read(100)
@@ -18,7 +18,7 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {'Content-Range' => '10-109/2577'}, status: 200, body: 'This is the response')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=10-109').and_return(fake_resp)
 
     rio.seek(10)
     read_result = rio.read(100)
@@ -29,7 +29,7 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 403, body: 'Please log in')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
 
     rio.seek(100)
     expect { rio.read(100) }.to raise_error(/replied with a 403 and refused/)
@@ -39,7 +39,7 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 416, body: 'You stepped off the ledge of the range')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
 
     rio.seek(100)
     expect(rio.read(100)).to be_nil
@@ -49,7 +49,7 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 403, body: 'Please log in')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
 
     rio.seek(100)
     # rubocop: disable Lint/AmbiguousBlockAssociation
@@ -60,7 +60,7 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 416, body: 'You jumped off the end of the file maam')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
 
     rio.seek(100)
     expect(rio.read(100)).to be_nil
@@ -69,14 +69,23 @@ describe FormatParser::RemoteIO do
   it 'does not overwrite size when the range cannot be satisfied and the response is 416' do
     rio = described_class.new('https://images.invalid/img.jpg')
 
-    fake_resp = double(headers: {'Content-Range' => 'bytes 0-0/13'}, status: 206, body: 'a')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=0-0').and_return(fake_resp)
+    fake_resp1 = double(headers: {'Content-Range' => 'bytes 0-0/13'}, status: 206, body: 'a')
+    fake_resp2 = double(headers: {}, status: 416, body: 'You jumped off the end of the file maam')
+
+    faraday_conn = instance_double(Faraday::Connection)
+    allow(Faraday).to receive(:new).and_return(faraday_conn)
+    expect(faraday_conn).to receive(:get)
+      .with('https://images.invalid/img.jpg', nil, range: 'bytes=0-0')
+      .ordered
+      .and_return(fake_resp1)
+    expect(faraday_conn).to receive(:get)
+      .with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199')
+      .ordered
+      .and_return(fake_resp2)
+
     rio.read(1)
 
     expect(rio.size).to eq(13)
-
-    fake_resp = double(headers: {}, status: 416, body: 'You jumped off the end of the file maam')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
 
     rio.seek(100)
     expect(rio.read(100)).to be_nil
@@ -88,7 +97,7 @@ describe FormatParser::RemoteIO do
     rio = described_class.new('https://images.invalid/img.jpg')
 
     fake_resp = double(headers: {}, status: 502, body: 'Guru meditation')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=100-199').and_return(fake_resp)
 
     rio.seek(100)
     expect { rio.read(100) }.to raise_error(/replied with a 502 and we might want to retry/)
@@ -100,7 +109,7 @@ describe FormatParser::RemoteIO do
     expect(rio.pos).to eq(0)
 
     fake_resp = double(headers: {'Content-Range' => 'bytes 0-0/13'}, status: 206, body: 'a')
-    expect(Faraday).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=0-0').and_return(fake_resp)
+    expect_any_instance_of(Faraday::Connection).to receive(:get).with('https://images.invalid/img.jpg', nil, range: 'bytes=0-0').and_return(fake_resp)
     rio.read(1)
 
     expect(rio.pos).to eq(1)


### PR DESCRIPTION
closes https://github.com/WeTransfer/format_parser/issues/189

This PR adds support to follow a redirect when downloading a file with `FormatParser.parse_http`

I was inspired by [this article](https://blog.thecodewhisperer.com/permalink/losing-time-to-faraday) which explains how to follow a redirect using Faraday