### PR TITLE
Add option :headers to parse_http

### DIFF
--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -43,5 +43,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'wetransfer_style', '0.5.0'
   spec.add_development_dependency 'parallel_tests'
-  spec.add_development_dependency 'pry-byebug'
 end

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'wetransfer_style', '0.5.0'
   spec.add_development_dependency 'parallel_tests'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -88,6 +88,7 @@ module FormatParser
   # given to `.parse`. The accepted keyword arguments are the same as the ones for `parse`.
   #
   # @param url[String, URI] the HTTP(S) URL to request the object from using Faraday and `Range:` requests
+  # @param headers[Hash] (optional) the HTTP headers to request the object from using Faraday
   # @param kwargs the keyword arguments to be delegated to `.parse`
   # @see {.parse}
   def self.parse_http(url, headers: {}, **kwargs)

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -90,11 +90,11 @@ module FormatParser
   # @param url[String, URI] the HTTP(S) URL to request the object from using Faraday and `Range:` requests
   # @param kwargs the keyword arguments to be delegated to `.parse`
   # @see {.parse}
-  def self.parse_http(url, **kwargs)
+  def self.parse_http(url, headers: {}, **kwargs)
     # Do not extract the filename, since the URL
     # can really be "anything". But if the caller
     # provides filename_hint it will be carried over
-    parse(RemoteIO.new(url), **kwargs)
+    parse(RemoteIO.new(url, headers: headers), **kwargs)
   end
 
   # Parses the file at the given `path` and returns the results as if it were any IO

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -24,9 +24,10 @@ class FormatParser::RemoteIO
   end
 
   # @param uri[URI, String] the remote URL to obtain
-  def initialize(uri)
+  def initialize(uri, headers: {})
     require 'faraday'
     require 'faraday_middleware/response/follow_redirects'
+    @headers = headers
     @uri = uri
     @pos = 0
     @remote_size = false
@@ -79,7 +80,7 @@ class FormatParser::RemoteIO
     # We use a GET and not a HEAD request followed by a GET because
     # S3 does not allow HEAD requests if you only presigned your URL for GETs, so we
     # combine the first GET of a segment and retrieving the size of the resource
-    conn = Faraday.new do |faraday|
+    conn = Faraday.new(headers: @headers) do |faraday|
       faraday.use FaradayMiddleware::FollowRedirects
       # we still need the default adapter, more details: https://blog.thecodewhisperer.com/permalink/losing-time-to-faraday
       faraday.adapter Faraday.default_adapter

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -24,6 +24,7 @@ class FormatParser::RemoteIO
   end
 
   # @param uri[URI, String] the remote URL to obtain
+  # @param headers[Hash] (optional) the HTTP headers to be used in the HTTP request
   def initialize(uri, headers: {})
     require 'faraday'
     require 'faraday_middleware/response/follow_redirects'

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -114,7 +114,7 @@ describe 'Fetching data from HTTP remotes' do
     it 'uses the provided headers to make the HTTP request' do
       file_information = FormatParser.parse_http(
         'http://localhost:9399//require-auth-and-redirect/TIFF/test.tif',
-       headers: {'Authorization' => 'any-token'}
+        headers: {'Authorization' => 'any-token'}
       )
       expect(file_information.format).to eq(:tif)
     end

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -110,14 +110,13 @@ describe 'Fetching data from HTTP remotes' do
     end
   end
 
-  context 'when the server requires authentication' do
-    it 'uses the provided headers to make the HTTP request' do
-      file_information = FormatParser.parse_http(
-        'http://localhost:9399//require-auth-and-redirect/TIFF/test.tif',
-        headers: {'Authorization' => 'any-token'}
-      )
-      expect(file_information.format).to eq(:tif)
-    end
+  it 'sends provided HTTP headers in the request' do
+    file_information = FormatParser.parse_http(
+      'http://localhost:9399//require-auth-and-redirect/TIFF/test.tif',
+      headers: {'Authorization' => 'any-token'}
+    )
+
+    expect(file_information.format).to eq(:tif)
   end
 
   after(:all) do


### PR DESCRIPTION
related to https://github.com/WeTransfer/format_parser/pull/190

It adds the option `:headers` to `FormatParser.parse_http`, so it's possible to download a file from an URL which requires some kind of authentication header.