### PR TITLE
Upgrade faraday dependency

### DIFF
--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ks', '~> 0.0'
   spec.add_dependency 'exifr', '~> 1', '>= 1.3.8'
   spec.add_dependency 'id3tag', '~> 0.14'
-  spec.add_dependency 'faraday', '~> 0.13'
-  spec.add_dependency 'faraday_middleware', '~> 0.14'
+  spec.add_dependency 'faraday', '~> 1.5.1'
+  spec.add_dependency 'faraday_middleware', '~> 1.0'
   spec.add_dependency 'measurometer', '~> 1'
 
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Faraday gem version used in this project is quite old (from early 2019). It might be nice to upgrade it so that projects using `format_parser` are allowed to benefit from new features of latest `faraday` version.

Checked rspec, it does not seem to break anything. Also tested manually and it seem to work for me.