### PR TITLE
Fix small and empty HTTP response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.29.1
+* Fix handling of 200 responses with `parse_http` as well as handling of very small responses which do not need range access
+
 ## 0.29.0
 * Add option `headers:` to `FormatParser.parse_http`
 

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '0.29.0'
+  VERSION = '0.29.1'
 end

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -97,12 +97,12 @@ class FormatParser::RemoteIO
       response_size = response.body.bytesize
       requested_range_size = range.end - range.begin + 1
       if response_size > requested_range_size
-        error_message = <<~ERROR
-          We requested #{requested_range_size} bytes, but the server sent us more
-          (#{response_size} bytes) - it likely has no `Range:` support.
-          The error occurred when talking to #{@uri})
-        ERROR
-        raise InvalidRequest.new(response.status, error_message)
+        error_message = [
+          "We requested #{requested_range_size} bytes, but the server sent us more",
+          "(#{response_size} bytes) - it likely has no `Range:` support.",
+          "The error occurred when talking to #{@uri})"
+        ]
+        raise InvalidRequest.new(response.status, error_message.join("\n"))
       end
       [response_size, response.body]
     when 206

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -19,22 +19,27 @@ describe 'Fetching data from HTTP remotes' do
       res.status = 302
       res.header['Location'] = req.path.sub('/redirect', '')
     end
-    @server.mount_proc '/empty' do |req, res|
+    @server.mount_proc '/empty' do |_req, res|
       res.status = 200
       res.body = ''
     end
+    @server.mount_proc '/tiny' do |_req, res|
+      res.status = 200
+      res.body = File.read(fixtures_dir + '/test.gif')
+    end
+
     trap('INT') { @server.stop }
     @server_thread = Thread.new { @server.start }
   end
 
-  it '#parse_http is called without any option' do
+  it 'works with .parse_http called without any options' do
     result = FormatParser.parse_http('http://localhost:9399/PNG/anim.png')
 
     expect(result.format).to eq(:png)
     expect(result.height_px).to eq(180)
   end
 
-  it '#parse_http is called with hash options' do
+  it 'works with .parse_http called with additional options' do
     fake_result = double(nature: :audio, format: :aiff)
     expect_any_instance_of(FormatParser::AIFFParser).to receive(:call).and_return(fake_result)
     results = FormatParser.parse_http('http://localhost:9399/PNG/anim.png', results: :all)
@@ -45,7 +50,14 @@ describe 'Fetching data from HTTP remotes' do
 
   it 'is able to cope with a 0-size resource which does not provide Content-Range' do
     file_information = FormatParser.parse_http('http://localhost:9399/empty')
+
     expect(file_information).to be_nil
+  end
+
+  it 'is able to cope with a tiny resource which fits into the first requested range completely' do
+    file_information = FormatParser.parse_http('http://localhost:9399/tiny')
+    expect(file_information).not_to be_nil
+    expect(file_information.nature).to eq(:image)
   end
 
   it 'parses the animated PNG over HTTP' do

--- a/spec/remote_fetching_spec.rb
+++ b/spec/remote_fetching_spec.rb
@@ -19,6 +19,10 @@ describe 'Fetching data from HTTP remotes' do
       res.status = 302
       res.header['Location'] = req.path.sub('/redirect', '')
     end
+    @server.mount_proc '/empty' do |req, res|
+      res.status = 200
+      res.body = ''
+    end
     trap('INT') { @server.stop }
     @server_thread = Thread.new { @server.start }
   end
@@ -37,6 +41,11 @@ describe 'Fetching data from HTTP remotes' do
 
     expect(results.count).to eq(2)
     expect(results).to include(fake_result)
+  end
+
+  it 'is able to cope with a 0-size resource which does not provide Content-Range' do
+    file_information = FormatParser.parse_http('http://localhost:9399/empty')
+    expect(file_information).to be_nil
   end
 
   it 'parses the animated PNG over HTTP' do


### PR DESCRIPTION
If a response is very small (or the HTTP range requested "rolls off" the end
of the resource body) S3 will respond with the full resource and with a 200 status code.
If a resource is empty no Range support will be available (and there is no good way to
address a 0-size resource using the HTTP Ranges specification).

To handle this better we will now allow small 200 responses to be treated as normal responses,
as long as they do not exceed the range size we request from the server.