### PR TITLE
revolve exception bug happening when the stts atom is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+* Resolve bug when `stts` atom is nil
+
 ## 1.2.0
 * Add support for `codecs` in moov_parser for video metadata
 

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
revolve exception bug happening when the stts atom is not contained in the item during codecs parsing