### PR TITLE
Prevent MP3Parser parsing WebP files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.2
+* Fix `MP3Parser` taking precedence when parsing `WEBP` files.
+
 ## 1.4.1
 * Skip Exif chunks that are malformed during `WEBP` parsing.
 

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -28,6 +28,7 @@ class FormatParser::MP3Parser
   # For some edge cases
   ZIP_LOCAL_ENTRY_SIGNATURE = "PK\x03\x04\x14\x00".b
   PNG_HEADER_BYTES = [137, 80, 78, 71, 13, 10, 26, 10].pack('C*')
+  WEBP_HEADER_REGEX = /RIFF.{4}WEBP/i
 
   MAGIC_LE = [0x49, 0x49, 0x2A, 0x0].pack('C4')
   MAGIC_BE = [0x4D, 0x4D, 0x0, 0x2A].pack('C4')
@@ -68,9 +69,10 @@ class FormatParser::MP3Parser
     # will terminate here. Same with PNGs. In the future
     # we should implement "confidence" for MP3 as of all our formats
     # it is by far the most lax.
-    header = safe_read(io, 8)
+    header = safe_read(io, 12)
     return if header.start_with?(ZIP_LOCAL_ENTRY_SIGNATURE)
     return if header.start_with?(PNG_HEADER_BYTES)
+    return if header.start_with?(WEBP_HEADER_REGEX)
 
     io.seek(0)
     return if TIFF_HEADER_BYTES.include?(safe_read(io, 4))


### PR DESCRIPTION
We have an edge case where the MP3Parser is running and returning something _"meaningful"_ for WebP files, causing them to be mislabled as MP3 files and incorrectly parsed. This PR adds protection against that edge case, similar to the protections added for similar cases with PNG and ZIP files.