### PR TITLE
Rename metrics

### DIFF
--- a/lib/care.rb
+++ b/lib/care.rb
@@ -170,10 +170,10 @@ class Care
     # @param io[IO] the IO to read from
     # @param page_i[Integer] which page (zero-based) to read
     def read_page(io, page_i)
-      Measurometer.increment_counter('format_parser.parser.Care.page_reads_from_upsteam', 1)
+      Measurometer.increment_counter('format_parser.parser.care.page_reads_from_upsteam', 1)
 
       io.seek(page_i * @page_size)
-      read_result = Measurometer.instrument('format_parser.Care.read_page') { io.read(@page_size) }
+      read_result = Measurometer.instrument('format_parser.care.read_page') { io.read(@page_size) }
       if read_result.nil?
         # If the read went past the end of the IO the read result will be nil,
         # so we know our IO is exhausted here

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -201,12 +201,12 @@ module FormatParser
   end
 
   def self.execute_parser_and_capture_expected_exceptions(parser, limited_io)
-    parser_name_for_instrumentation = parser.class.to_s.split('::').last
+    parser_name_for_instrumentation = parser.class.to_s.split('::').last.underscore
     Measurometer.instrument('format_parser.parser.%s' % parser_name_for_instrumentation) do
       parser.call(limited_io).tap do |result|
         if result
-          Measurometer.increment_counter('format_parser.detected_natures.%s' % result.nature, 1)
-          Measurometer.increment_counter('format_parser.detected_formats.%s' % result.format, 1)
+          Measurometer.increment_counter('format_parser.detected_natures', 1, nature: result.nature)
+          Measurometer.increment_counter('format_parser.detected_formats', 1, format: result.format)
         end
       end
     end

--- a/lib/format_parser.rb
+++ b/lib/format_parser.rb
@@ -20,6 +20,7 @@ module FormatParser
   require_relative 'care'
   require_relative 'active_storage/blob_analyzer'
   require_relative 'text'
+  require_relative 'string'
 
   # Define Measurometer in the internal namespace as well
   # so that we stay compatible for the applications that use it

--- a/lib/parsers/exif_parser.rb
+++ b/lib/parsers/exif_parser.rb
@@ -173,7 +173,7 @@ module FormatParser::EXIFParser
   EXIFR.logger = Logger.new(nil)
 
   def exif_from_tiff_io(constrained_io, should_include_sub_ifds = false)
-    Measurometer.instrument('format_parser.EXIFParser.exif_from_tiff_io') do
+    Measurometer.instrument('format_parser.exif_parser.exif_from_tiff_io') do
       extended_io = IOExt.new(constrained_io)
       exif_raw_data = EXIFR::TIFF.new(extended_io)
 

--- a/lib/parsers/jpeg_parser.rb
+++ b/lib/parsers/jpeg_parser.rb
@@ -69,7 +69,7 @@ class FormatParser::JPEGParser
       end
     end
 
-    Measurometer.add_distribution_value('format_parser.JPEGParser.bytes_read_until_capture', @buf.pos)
+    Measurometer.add_distribution_value('format_parser.jpeg_parser.bytes_read_until_capture', @buf.pos)
 
     # A single file might contain multiple EXIF data frames. In a JPEG this would
     # manifest as multiple APP1 markers. The way different programs handle these
@@ -156,7 +156,7 @@ class FormatParser::JPEGParser
     # Use StringIO.new instead of #write - https://github.com/aws/aws-sdk-ruby/issues/785#issuecomment-95456838
     exif_buf = StringIO.new(safe_read(@buf, app1_frame_content_length - EXIF_MAGIC_STRING.bytesize))
 
-    Measurometer.add_distribution_value('format_parser.JPEGParser.bytes_sent_to_exif_parser', exif_buf.size)
+    Measurometer.add_distribution_value('format_parser.jpeg_parser.bytes_sent_to_exif_parser', exif_buf.size)
 
     @exif_data_frames << exif_from_tiff_io(exif_buf)
   rescue EXIFR::MalformedTIFF

--- a/lib/parsers/moov_parser.rb
+++ b/lib/parsers/moov_parser.rb
@@ -37,7 +37,7 @@ class FormatParser::MOOVParser
     # size that gets parsed just before.
     max_read_offset = 0xFFFFFFFF
     decoder = Decoder.new
-    atom_tree = Measurometer.instrument('format_parser.Decoder.extract_atom_stream') do
+    atom_tree = Measurometer.instrument('format_parser.decoder.extract_atom_stream') do
       decoder.extract_atom_stream(io, max_read_offset)
     end
 

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -66,13 +66,13 @@ class FormatParser::ReadLimiter
 
   # Sends the metrics about the state of this ReadLimiter to a Measurometer
   #
-  # @param prefix[String] the prefix to set. For example, with prefix "TIFF" the metrics will be called
-  #   `format_parser.TIFF.read_limiter.num_seeks` and so forth
+  # @param parser[String] the prefix to set. For example, with prefix "TIFF" the metrics will be called
+  #   `format_parser.read_limiter.num_seeks` and so forth
   # @return void
-  def send_metrics(prefix)
-    Measurometer.add_distribution_value('format_parser.%s.read_limiter.num_seeks' % prefix, @seeks)
-    Measurometer.add_distribution_value('format_parser.%s.read_limiter.num_reads' % prefix, @reads)
-    Measurometer.add_distribution_value('format_parser.%s.read_limiter.read_bytes' % prefix, @bytes)
+  def send_metrics(parser)
+    Measurometer.add_distribution_value('format_parser.read_limiter.num_seeks', @seeks, parser: parser)
+    Measurometer.add_distribution_value('format_parser.read_limiter.num_reads', @reads, parser: parser)
+    Measurometer.add_distribution_value('format_parser.read_limiter.read_bytes', @bytes, parser: parser)
   end
 
   # Resets all the recorded call counters so that the object can be reused for the next parser,

--- a/lib/read_limiter.rb
+++ b/lib/read_limiter.rb
@@ -66,8 +66,7 @@ class FormatParser::ReadLimiter
 
   # Sends the metrics about the state of this ReadLimiter to a Measurometer
   #
-  # @param parser[String] the prefix to set. For example, with prefix "TIFF" the metrics will be called
-  #   `format_parser.read_limiter.num_seeks` and so forth
+  # @param parser[String] the parser to add as a tag.
   # @return void
   def send_metrics(parser)
     Measurometer.add_distribution_value('format_parser.read_limiter.num_seeks', @seeks, parser: parser)

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -63,7 +63,7 @@ class FormatParser::RemoteIO
   # @return [String] the read bytes
   def read(n_bytes)
     http_range = (@pos..(@pos + n_bytes - 1))
-    maybe_size, maybe_body = Measurometer.instrument('format_parser.RemoteIO.read') { request_range(http_range) }
+    maybe_size, maybe_body = Measurometer.instrument('format_parser.remote_io.read') { request_range(http_range) }
     if maybe_size && maybe_body
       @remote_size = maybe_size
       @pos += maybe_body.bytesize
@@ -125,10 +125,10 @@ class FormatParser::RemoteIO
       # cannot hint size with this response - at lease not when working with S3
       nil
     when 500..599
-      Measurometer.increment_counter('format_parser.RemoteIO.upstream50x_errors', 1)
+      Measurometer.increment_counter('format_parser.remote_io.upstream50x_errors', 1)
       raise IntermittentFailure.new(response.status, "Server at #{@uri} replied with a #{response.status} and we might want to retry")
     else
-      Measurometer.increment_counter('format_parser.RemoteIO.invalid_request_errors', 1)
+      Measurometer.increment_counter('format_parser.remote_io.invalid_request_errors', 1)
       raise InvalidRequest.new(response.status, "Server at #{@uri} replied with a #{response.status} and refused our request")
     end
   end

--- a/lib/string.rb
+++ b/lib/string.rb
@@ -1,0 +1,9 @@
+class String
+  def underscore
+    self.gsub(/::/, '/').
+    gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+    gsub(/([a-z\d])([A-Z])/,'\1_\2').
+    tr("-", "_").
+    downcase
+  end
+end

--- a/lib/string.rb
+++ b/lib/string.rb
@@ -1,9 +1,9 @@
 class String
   def underscore
-    self.gsub(/::/, '/').
-    gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-    gsub(/([a-z\d])([A-Z])/,'\1_\2').
-    tr("-", "_").
+    gsub(/::/, '/').
+    gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
+    gsub(/([a-z\d])([A-Z])/, '\1_\2').
+    tr('-', '_').
     downcase
   end
 end


### PR DESCRIPTION
This PR renames the metrics to make sure they're all:

- Written in underscore / snake case (for consistency)
- Uses tags where appropriate (this would prevent metric systems from being flooded with similar looking metric names)