### PR TITLE
[NO JIRA] Clear Authorization Header on Redirect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         run: bundle exec rubocop
   test:
     name: Specs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   lint:
     name: Code Style
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0.pre (Prerelease)
+## 2.0.0.pre.2 (Prerelease)
 * Drop support for Ruby `<2.7`.
 * Drop faraday dependencies.
 * Loosen version constraints on other dependencies.

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'wetransfer_style', '1.0.0'
   spec.add_development_dependency 'yard'
 end

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.0.0.pre'
+  VERSION = '2.0.0.pre.2'
 end

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -141,7 +141,7 @@ class FormatParser::RemoteIO
       # to be 206
       [size, response.body]
     when Net::HTTPMovedPermanently, Net::HTTPFound, Net::HTTPSeeOther, Net::HTTPTemporaryRedirect, Net::HTTPPermanentRedirect
-      raise RedirectLimitReached.new(uri) if redirects == 0
+      raise RedirectLimitReached, uri if redirects == 0
       location = response['location']
       if location
         new_uri = redirect_uri(location, uri)

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -122,7 +122,7 @@ class FormatParser::RemoteIO
         error_message = [
           "We requested #{requested_range_size} bytes, but the server sent us more",
           "(#{response_size} bytes) - it likely has no `Range:` support.",
-          "The error occurred when talking to #{uri})"
+          "The error occurred when talking to #{uri}"
         ]
         raise InvalidRequest.new(response.code, error_message.join("\n"))
       end
@@ -141,7 +141,7 @@ class FormatParser::RemoteIO
       # to be 206
       [size, response.body]
     when Net::HTTPMovedPermanently, Net::HTTPFound, Net::HTTPSeeOther, Net::HTTPTemporaryRedirect, Net::HTTPPermanentRedirect
-      raise RedirectLimitReached(uri) if redirects == 0
+      raise RedirectLimitReached.new(uri) if redirects == 0
       location = response['location']
       if location
         new_uri = redirect_uri(location, uri)

--- a/lib/remote_io.rb
+++ b/lib/remote_io.rb
@@ -144,7 +144,10 @@ class FormatParser::RemoteIO
       raise RedirectLimitReached(uri) if redirects == 0
       location = response['location']
       if location
-        request_range(range, redirect_uri(location, uri), redirects - 1)
+        new_uri = redirect_uri(location, uri)
+        # Clear the Authorization header if the new URI has a different host.
+        @headers.delete('Authorization') unless [@uri.scheme, @uri.host, @uri.port] == [new_uri.scheme, new_uri.host, new_uri.port]
+        request_range(range, new_uri, redirects - 1)
       else
         raise InvalidRequest.new(response.code, "Server at #{uri} replied with a #{response.code}, indicating redirection; however, the location header was empty.")
       end

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -251,6 +251,7 @@ describe FormatParser::RemoteIO do
   end
 
   # 5XX
+
   (500..599).each do |code|
     context "when the response status code is #{code}" do
       it 'raises an error' do

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -3,187 +3,343 @@ require 'spec_helper'
 describe FormatParser::RemoteIO do
   it_behaves_like 'an IO object compatible with IOConstraint'
 
-  it 'returns the partial content when the server supplies a 206 status' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
-    response['Content-Range'] = '10-109/2577'
-    allow(response).to receive(:body).and_return('Response body')
+  # 2XX
 
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
+  context 'when the response code is 200 (OK)' do
+    context 'when the response size does not exceed the requested range' do
+      it 'returns the entire response body' do
+        url = 'https://images.invalid/img.jpg'
+        response = Net::HTTPOK.new('2', '200', 'OK')
+        allow(response).to receive(:body).and_return('Response body')
 
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-      a_hash_including('range' => 'bytes=10-109')
-    )
+        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+        allow(Net::HTTP).to receive(:request_get).and_return(response)
 
-    rio = described_class.new(url)
-    rio.seek(10)
-    read_result = rio.read(100)
+        expect(Net::HTTP).to receive(:request_get).with(
+          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
+          a_hash_including('range' => 'bytes=10-109')
+        )
 
-    expect(read_result).to eq(response.body)
+        rio = described_class.new(url)
+        rio.seek(10)
+        read_result = rio.read(100)
+
+        expect(read_result).to eq(response.body)
+      end
+    end
+
+    context 'when the response size exceeds the requested range' do
+      it 'raises an error' do
+        url = 'https://images.invalid/img.jpg'
+        response = Net::HTTPOK.new('2', '200', 'OK')
+        allow(response).to receive(:body).and_return('This response is way longer than 10 bytes.')
+
+        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+        allow(Net::HTTP).to receive(:request_get).and_return(response)
+
+        expect(Net::HTTP).to receive(:request_get).with(
+          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
+          a_hash_including('range' => 'bytes=10-19')
+        )
+
+        rio = described_class.new(url)
+        rio.seek(10)
+        expect { rio.read(10) }.to raise_error(
+          "We requested 10 bytes, but the server sent us more\n"\
+          "(42 bytes) - it likely has no `Range:` support.\n"\
+          "The error occurred when talking to #{url}"
+        )
+      end
+    end
   end
 
-  it 'returns the entire content when the server supplies the Content-Range response but sends a 200 status' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPOK.new('2', '200', 'OK')
-    allow(response).to receive(:body).and_return('Response body')
+  context 'when the response status code is 206 (Partial Content)' do
+    context 'when the Content-Range header is present' do
+      it 'returns the response body' do
+        url = 'https://images.invalid/img.jpg'
+        response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
+        response['Content-Range'] = '10-109/2577'
+        allow(response).to receive(:body).and_return('Response body')
 
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
+        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+        allow(Net::HTTP).to receive(:request_get).and_return(response)
 
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-      a_hash_including('range' => 'bytes=10-109')
-    )
+        expect(Net::HTTP).to receive(:request_get).with(
+          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
+          a_hash_including('range' => 'bytes=10-109')
+        )
 
-    rio = described_class.new(url)
-    rio.seek(10)
-    read_result = rio.read(100)
+        rio = described_class.new(url)
+        rio.seek(10)
+        read_result = rio.read(100)
 
-    expect(read_result).to eq(response.body)
+        expect(read_result).to eq(response.body)
+      end
+
+      it 'maintains and exposes pos' do
+        url = 'https://images.invalid/img.jpg'
+        response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
+        response['Content-Range'] = 'bytes 0-0/13'
+        allow(response).to receive(:body).and_return('a')
+
+        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+        allow(Net::HTTP).to receive(:request_get).and_return(response)
+
+        expect(Net::HTTP).to receive(:request_get).with(
+          an_object_satisfying { |uri| uri.to_s == url },
+          a_hash_including('range' => 'bytes=0-0')
+        )
+
+        rio = described_class.new(url)
+        expect(rio.pos).to eq(0)
+        rio.read(1)
+        expect(rio.pos).to eq(1)
+      end
+    end
+
+    context 'when the Content-Range header is not present' do
+      it 'raises an error' do
+        url = 'https://images.invalid/img.jpg'
+        response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
+
+        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+        allow(Net::HTTP).to receive(:request_get).and_return(response)
+
+        expect(Net::HTTP).to receive(:request_get).with(
+          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
+          a_hash_including('range' => 'bytes=10-109')
+        )
+
+        rio = described_class.new(url)
+        rio.seek(10)
+        expect { rio.read(100) }.to raise_error("The server replied with 206 status but no Content-Range at #{url}")
+      end
+    end
   end
 
-  it 'raises a specific error for all 4xx responses except 416' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPForbidden.new('2', '403', 'Forbidden')
+  # 3XX
 
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
+  context 'when the response code is 301 (Moved Permanently), 302 (Found), 303 (See Other), 307 (Temporary Redirect) or  308 (Permanent Redirect)' do
+    context 'when the location header is present and the redirect limit is not exceeded' do
+      context 'when the location is absolute' do
+        it 'redirects to the specified location, without the Authorization header' do
+          initial_url = 'https://my_images.invalid/my_image'
+          redirect_url = 'https://images.invalid/img.jpg'
+          final_response = Net::HTTPOK.new('2', '200', 'OK')
+          allow(final_response).to receive(:body).and_return('Response body')
 
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| uri.to_s == url },
-      a_hash_including('range' => 'bytes=100-199')
-    )
+          %w[301 302 303 307 308].each do |code|
+            redirect_response = Net::HTTPFound.new('2', code, 'Redirect')
+            redirect_response['location'] = redirect_url
 
-    rio = described_class.new(url)
-    rio.seek(100)
+            allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(redirect_response, final_response)
+            allow(Net::HTTP).to receive(:request_get).and_return(redirect_response, final_response)
 
-    expect { rio.read(100) }.to raise_error(/replied with a 403 and refused/)
+            expect(Net::HTTP).to receive(:request_get).with(
+              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == initial_url },
+              a_hash_including('range' => 'bytes=10-109', 'Authorization' => 'token')
+            ).ordered
+            expect(Net::HTTP).to receive(:request_get).with(
+              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == redirect_url },
+              a_hash_including('range' => 'bytes=10-109').and(excluding('Authorization'))
+            ).ordered
+
+            rio = described_class.new(initial_url, headers: { 'Authorization' => 'token' })
+            rio.seek(10)
+            read_result = rio.read(100)
+
+            expect(read_result).to eq(final_response.body)
+          end
+        end
+      end
+
+      context 'when the location is relative' do
+        it 'redirects to the specified location under the same host, with the same Authorization header' do
+          initial_url = 'https://images.invalid/my_image'
+          redirect_url = '/img.jpg'
+          final_response = Net::HTTPOK.new('2', '200', 'OK')
+          allow(final_response).to receive(:body).and_return('Response body')
+
+          %w[301 302 303 307 308].each do |code|
+            redirect_response = Net::HTTPFound.new('2', code, 'Redirect')
+            redirect_response['location'] = redirect_url
+
+            allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(redirect_response, final_response)
+            allow(Net::HTTP).to receive(:request_get).and_return(redirect_response, final_response)
+
+            expect(Net::HTTP).to receive(:request_get).with(
+              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == initial_url },
+              a_hash_including('range' => 'bytes=10-109', 'Authorization' => 'token')
+            ).ordered
+            expect(Net::HTTP).to receive(:request_get).with(
+              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == 'https://images.invalid/img.jpg' },
+              a_hash_including('range' => 'bytes=10-109', 'Authorization' => 'token')
+            ).ordered
+
+            rio = described_class.new(initial_url, headers: { 'Authorization' => 'token' })
+            rio.seek(10)
+            read_result = rio.read(100)
+
+            expect(read_result).to eq(final_response.body)
+          end
+        end
+      end
+    end
+
+    context 'when the location header is not present' do
+      it 'raises an error' do
+        url = 'https://images.invalid/my_image'
+
+        %w[301 302 303 307 308].each do |code|
+          response = Net::HTTPFound.new('2', code, 'Redirect')
+
+          allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+          allow(Net::HTTP).to receive(:request_get).and_return(response)
+
+          expect(Net::HTTP).to receive(:request_get).with(
+            an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
+            a_hash_including('range' => 'bytes=10-109')
+          )
+
+          rio = described_class.new(url)
+          rio.seek(10)
+
+          expect { rio.read(100) }.to raise_error("Server at #{url} replied with a #{code}, indicating redirection; however, the location header was empty.")
+        end
+      end
+    end
+
+    context 'when the redirect limit is exceeded' do
+      it 'raises an error' do
+        url = 'https://images.invalid/my_image'
+        redirect_url = 'https://images.invalid/img.jpg'
+
+        {
+          '301' => Net::HTTPMovedPermanently,
+          '302' => Net::HTTPFound,
+          '303' => Net::HTTPSeeOther,
+          '307' => Net::HTTPTemporaryRedirect,
+          '308' => Net::HTTPPermanentRedirect,
+        }.each do |code, response_class|
+          response = response_class.new('2', code, 'Redirect')
+          response['location'] = redirect_url
+
+          allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+          allow(Net::HTTP).to receive(:request_get).and_return(response)
+
+          expect(Net::HTTP).to receive(:request_get).with(
+            an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
+            a_hash_including('range' => 'bytes=10-109')
+          )
+
+          rio = described_class.new(url)
+          rio.seek(10)
+          expect { rio.read(100) }.to raise_error("Too many redirects; last one to: #{redirect_url}")
+        end
+      end
+    end
   end
 
-  it 'returns nil on a 416 response' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPRangeNotSatisfiable.new('2', '416', 'Range Not Satisfiable')
+  # 4XX
 
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
+  context 'when the response status code is 416 (Range Not Satisfiable)' do
+    it 'returns nil' do
+      url = 'https://images.invalid/img.jpg'
+      response = Net::HTTPRangeNotSatisfiable.new('2', '416', 'Range Not Satisfiable')
 
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| uri.to_s == url },
-      a_hash_including('range' => 'bytes=100-199')
-    )
+      allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+      allow(Net::HTTP).to receive(:request_get).and_return(response)
 
-    rio = described_class.new(url)
-    rio.seek(100)
-
-    expect(rio.read(100)).to be_nil
-  end
-
-  it 'sets the status_code of the exception on a 4xx response from upstream' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPForbidden.new('2', '403', 'Forbidden')
-
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| uri.to_s == url },
-      a_hash_including('range' => 'bytes=100-199')
-    )
-
-    rio = described_class.new(url)
-    rio.seek(100)
-    expect { rio.read(100) }.to(raise_error { |e| expect(e.status_code).to eq(403) })
-  end
-
-  it 'returns a nil when the range cannot be satisfied and the response is 416' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPRangeNotSatisfiable.new('2', '416', 'Range Not Satisfiable')
-
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| uri.to_s == url },
-      a_hash_including('range' => 'bytes=100-199')
-    )
-
-    rio = described_class.new(url)
-    rio.seek(100)
-
-    expect(rio.read(100)).to be_nil
-  end
-
-  it 'does not overwrite size when the range cannot be satisfied and the response is 416' do
-    url = 'https://images.invalid/img.jpg'
-    response_1 = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
-    response_1['Content-Range'] = 'bytes 0-0/13'
-    allow(response_1).to receive(:body).and_return('Response body')
-    response_2 = Net::HTTPRangeNotSatisfiable.new('2', '416', 'Range Not Satisfiable')
-
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response_1, response_2)
-    allow(Net::HTTP).to receive(:request_get).and_return(response_1, response_2)
-
-    expect(Net::HTTP).to receive(:request_get)
-      .with(
-        an_object_satisfying { |uri| uri.to_s == url },
-        a_hash_including('range' => 'bytes=0-0')
-      )
-      .ordered
-    expect(Net::HTTP).to receive(:request_get)
-      .with(
+      expect(Net::HTTP).to receive(:request_get).with(
         an_object_satisfying { |uri| uri.to_s == url },
         a_hash_including('range' => 'bytes=100-199')
       )
-      .ordered
 
-    rio = described_class.new(url)
-    rio.read(1)
+      rio = described_class.new(url)
+      rio.seek(100)
 
-    expect(rio.size).to eq(13)
+      expect(rio.read(100)).to be_nil
+    end
 
-    rio.seek(100)
+    it 'does not change pos or size' do
+      url = 'https://images.invalid/img.jpg'
+      first_response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
+      first_response['Content-Range'] = 'bytes 0-0/13'
+      allow(first_response).to receive(:body).and_return('Response body')
+      second_response = Net::HTTPRangeNotSatisfiable.new('2', '416', 'Range Not Satisfiable')
 
-    expect(rio.read(100)).to be_nil
-    expect(rio.size).to eq(13)
+      allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(first_response, second_response)
+      allow(Net::HTTP).to receive(:request_get).and_return(first_response, second_response)
+
+      expect(Net::HTTP).to receive(:request_get)
+        .with(
+          an_object_satisfying { |uri| uri.to_s == url },
+          a_hash_including('range' => 'bytes=0-0')
+        )
+        .ordered
+      expect(Net::HTTP).to receive(:request_get)
+        .with(
+          an_object_satisfying { |uri| uri.to_s == url },
+          a_hash_including('range' => 'bytes=100-199')
+        )
+        .ordered
+
+      rio = described_class.new(url)
+      rio.read(1)
+
+      expect(rio.size).to eq(13)
+
+      rio.seek(100)
+      rio.read(100)
+
+      expect(rio.pos).to eq(100)
+      expect(rio.size).to eq(13)
+    end
   end
 
-  it 'raises a specific error for all 5xx responses' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPBadGateway.new('2', '502', 'Bad Gateway')
+  context 'when the response status code is 4xx' do
+    it 'raises an error' do
+      url = 'https://images.invalid/img.jpg'
+      [*'400'..'415', *'417'..'499'].each do |code|
+        response = Net::HTTPClientError.new('2', code, 'Client Error')
 
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
+        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+        allow(Net::HTTP).to receive(:request_get).and_return(response)
 
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| uri.to_s == url },
-      a_hash_including('range' => 'bytes=100-199')
-    )
+        expect(Net::HTTP).to receive(:request_get).with(
+          an_object_satisfying { |uri| uri.to_s == url },
+          a_hash_including('range' => 'bytes=100-199')
+        )
 
-    rio = described_class.new(url)
-    rio.seek(100)
+        rio = described_class.new(url)
+        rio.seek(100)
 
-    expect { rio.read(100) }.to raise_error(/replied with a 502 and we might want to retry/)
+        expect { rio.read(100) }.to raise_error("Server at #{url} replied with a #{code} and refused our request")
+      end
+    end
   end
 
-  it 'maintains and exposes #pos' do
-    url = 'https://images.invalid/img.jpg'
-    response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
-    response['Content-Range'] = 'bytes 0-0/13'
-    allow(response).to receive(:body).and_return('a')
+  # 5XX
 
-    allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-    allow(Net::HTTP).to receive(:request_get).and_return(response)
+  context 'when the response status code is 5xx' do
+    it 'raises an error' do
+      url = 'https://images.invalid/img.jpg'
+      ('500'..'599').each do |code|
+        response = Net::HTTPServerError.new('2', code, 'Server Error')
 
-    expect(Net::HTTP).to receive(:request_get).with(
-      an_object_satisfying { |uri| uri.to_s == url },
-      a_hash_including('range' => 'bytes=0-0')
-    )
+        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
+        allow(Net::HTTP).to receive(:request_get).and_return(response)
 
-    rio = described_class.new(url)
-    expect(rio.pos).to eq(0)
-    rio.read(1)
-    expect(rio.pos).to eq(1)
+        expect(Net::HTTP).to receive(:request_get).with(
+          an_object_satisfying { |uri| uri.to_s == url },
+          a_hash_including('range' => 'bytes=100-199')
+        )
+
+        rio = described_class.new(url)
+        rio.seek(100)
+
+        expect { rio.read(100) }.to raise_error("Server at #{url} replied with a #{code} and we might want to retry")
+      end
+    end
   end
 end

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -187,7 +187,6 @@ describe FormatParser::RemoteIO do
         end
       end
     end
-
   end
 
   # 4XX

--- a/spec/remote_io_spec.rb
+++ b/spec/remote_io_spec.rb
@@ -9,46 +9,39 @@ describe FormatParser::RemoteIO do
     context 'when the response size does not exceed the requested range' do
       it 'returns the entire response body' do
         url = 'https://images.invalid/img.jpg'
-        response = Net::HTTPOK.new('2', '200', 'OK')
-        allow(response).to receive(:body).and_return('Response body')
+        body = 'response body'
 
-        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-        allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-        expect(Net::HTTP).to receive(:request_get).with(
-          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-          a_hash_including('range' => 'bytes=10-109')
-        )
+        stub = stub_request(:get, url)
+          .with(headers: { 'range' => 'bytes=10-109' })
+          .to_return(body: body, status: 200)
 
         rio = described_class.new(url)
         rio.seek(10)
         read_result = rio.read(100)
 
-        expect(read_result).to eq(response.body)
+        expect(read_result).to eq(body)
+        expect(stub).to have_been_requested
       end
     end
 
     context 'when the response size exceeds the requested range' do
       it 'raises an error' do
         url = 'https://images.invalid/img.jpg'
-        response = Net::HTTPOK.new('2', '200', 'OK')
-        allow(response).to receive(:body).and_return('This response is way longer than 10 bytes.')
+        body = 'This response is way longer than 10 bytes.'
 
-        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-        allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-        expect(Net::HTTP).to receive(:request_get).with(
-          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-          a_hash_including('range' => 'bytes=10-19')
-        )
+        stub = stub_request(:get, url)
+          .with(headers: { 'range' => 'bytes=10-19' })
+          .to_return(body: body, status: 200)
 
         rio = described_class.new(url)
         rio.seek(10)
+
         expect { rio.read(10) }.to raise_error(
           "We requested 10 bytes, but the server sent us more\n"\
           "(42 bytes) - it likely has no `Range:` support.\n"\
           "The error occurred when talking to #{url}"
         )
+        expect(stub).to have_been_requested
       end
     end
   end
@@ -57,187 +50,144 @@ describe FormatParser::RemoteIO do
     context 'when the Content-Range header is present' do
       it 'returns the response body' do
         url = 'https://images.invalid/img.jpg'
-        response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
-        response['Content-Range'] = '10-109/2577'
-        allow(response).to receive(:body).and_return('Response body')
+        body = 'response body'
 
-        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-        allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-        expect(Net::HTTP).to receive(:request_get).with(
-          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-          a_hash_including('range' => 'bytes=10-109')
-        )
+        stub = stub_request(:get, url)
+          .with(headers: { 'range' => 'bytes=10-109' })
+          .to_return(body: body, headers: { 'Content-Range' => '10-109/2577' }, status: 206)
 
         rio = described_class.new(url)
         rio.seek(10)
         read_result = rio.read(100)
 
-        expect(read_result).to eq(response.body)
+        expect(read_result).to eq(body)
+        expect(stub).to have_been_requested
       end
 
       it 'maintains and exposes pos' do
         url = 'https://images.invalid/img.jpg'
-        response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
-        response['Content-Range'] = 'bytes 0-0/13'
-        allow(response).to receive(:body).and_return('a')
 
-        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-        allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-        expect(Net::HTTP).to receive(:request_get).with(
-          an_object_satisfying { |uri| uri.to_s == url },
-          a_hash_including('range' => 'bytes=0-0')
-        )
+        stub = stub_request(:get, url)
+          .with(headers: { 'range' => 'bytes=0-0' })
+          .to_return(body: 'a', headers: { 'Content-Range' => '0-0/13' }, status: 206)
 
         rio = described_class.new(url)
+
         expect(rio.pos).to eq(0)
+
         rio.read(1)
+
         expect(rio.pos).to eq(1)
+        expect(stub).to have_been_requested
       end
     end
 
     context 'when the Content-Range header is not present' do
       it 'raises an error' do
         url = 'https://images.invalid/img.jpg'
-        response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
 
-        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-        allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-        expect(Net::HTTP).to receive(:request_get).with(
-          an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-          a_hash_including('range' => 'bytes=10-109')
-        )
+        stub = stub_request(:get, url)
+          .with(headers: { 'range' => 'bytes=10-109' })
+          .to_return(status: 206)
 
         rio = described_class.new(url)
         rio.seek(10)
+
         expect { rio.read(100) }.to raise_error("The server replied with 206 status but no Content-Range at #{url}")
+        expect(stub).to have_been_requested
       end
     end
   end
 
   # 3XX
 
-  context 'when the response code is 301 (Moved Permanently), 302 (Found), 303 (See Other), 307 (Temporary Redirect) or  308 (Permanent Redirect)' do
-    context 'when the location header is present and the redirect limit is not exceeded' do
-      context 'when the location is absolute' do
-        it 'redirects to the specified location, without the Authorization header' do
-          initial_url = 'https://my_images.invalid/my_image'
-          redirect_url = 'https://images.invalid/img.jpg'
-          final_response = Net::HTTPOK.new('2', '200', 'OK')
-          allow(final_response).to receive(:body).and_return('Response body')
+  [301, 302, 303, 307, 308].each do |code|
+    context "when the response code is #{code}" do
+      context 'when the location header is present and the redirect limit is not exceeded' do
+        context 'when the location is absolute' do
+          it 'redirects to the specified location, without the Authorization header' do
+            redirecting_url = 'https://my_images.invalid/my_image'
+            destination_url = 'https://images.invalid/img.jpg'
+            body = 'response body'
 
-          %w[301 302 303 307 308].each do |code|
-            redirect_response = Net::HTTPFound.new('2', code, 'Redirect')
-            redirect_response['location'] = redirect_url
+            redirect_stub = stub_request(:get, redirecting_url)
+              .with(headers: { 'Authorization' => 'token', 'range' => 'bytes=10-109' })
+              .to_return(headers: { 'location' => destination_url }, status: code)
+            destination_stub = stub_request(:get, destination_url)
+              .with { |request| request.headers['Range'] == 'bytes=10-109' && !request.headers.key?('Authorization') }
+              .to_return(body: body, status: 200)
 
-            allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(redirect_response, final_response)
-            allow(Net::HTTP).to receive(:request_get).and_return(redirect_response, final_response)
-
-            expect(Net::HTTP).to receive(:request_get).with(
-              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == initial_url },
-              a_hash_including('range' => 'bytes=10-109', 'Authorization' => 'token')
-            ).ordered
-            expect(Net::HTTP).to receive(:request_get).with(
-              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == redirect_url },
-              a_hash_including('range' => 'bytes=10-109').and(excluding('Authorization'))
-            ).ordered
-
-            rio = described_class.new(initial_url, headers: { 'Authorization' => 'token' })
+            rio = described_class.new(redirecting_url, headers: { 'Authorization' => 'token' })
             rio.seek(10)
             read_result = rio.read(100)
 
-            expect(read_result).to eq(final_response.body)
+            expect(read_result).to eq(body)
+            expect(redirect_stub).to have_been_requested
+            expect(destination_stub).to have_been_requested
+          end
+        end
+
+        context 'when the location is relative' do
+          it 'redirects to the specified location under the same host, with the same Authorization header' do
+            host = 'https://images.invalid'
+            redirecting_path = '/my_image'
+            redirecting_url = host + redirecting_path
+            destination_path = '/img.jpg'
+            destination_url = host + destination_path
+            body = 'response body'
+
+            redirect_stub = stub_request(:get, redirecting_url)
+              .with(headers: { 'Authorization' => 'token', 'range' => 'bytes=10-109' })
+              .to_return(headers: { 'location' => destination_path }, status: code)
+            destination_stub = stub_request(:get, destination_url)
+              .with(headers: { 'Authorization' => 'token', 'range' => 'bytes=10-109' })
+              .to_return(body: body, status: 200)
+
+            rio = described_class.new(redirecting_url, headers: { 'Authorization' => 'token' })
+            rio.seek(10)
+            read_result = rio.read(100)
+
+            expect(read_result).to eq(body)
+            expect(redirect_stub).to have_been_requested
+            expect(destination_stub).to have_been_requested
           end
         end
       end
 
-      context 'when the location is relative' do
-        it 'redirects to the specified location under the same host, with the same Authorization header' do
-          initial_url = 'https://images.invalid/my_image'
-          redirect_url = '/img.jpg'
-          final_response = Net::HTTPOK.new('2', '200', 'OK')
-          allow(final_response).to receive(:body).and_return('Response body')
+      context 'when the location header is not present' do
+        it 'raises an error' do
+          url = 'https://images.invalid/my_image'
 
-          %w[301 302 303 307 308].each do |code|
-            redirect_response = Net::HTTPFound.new('2', code, 'Redirect')
-            redirect_response['location'] = redirect_url
-
-            allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(redirect_response, final_response)
-            allow(Net::HTTP).to receive(:request_get).and_return(redirect_response, final_response)
-
-            expect(Net::HTTP).to receive(:request_get).with(
-              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == initial_url },
-              a_hash_including('range' => 'bytes=10-109', 'Authorization' => 'token')
-            ).ordered
-            expect(Net::HTTP).to receive(:request_get).with(
-              an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == 'https://images.invalid/img.jpg' },
-              a_hash_including('range' => 'bytes=10-109', 'Authorization' => 'token')
-            ).ordered
-
-            rio = described_class.new(initial_url, headers: { 'Authorization' => 'token' })
-            rio.seek(10)
-            read_result = rio.read(100)
-
-            expect(read_result).to eq(final_response.body)
-          end
-        end
-      end
-    end
-
-    context 'when the location header is not present' do
-      it 'raises an error' do
-        url = 'https://images.invalid/my_image'
-
-        %w[301 302 303 307 308].each do |code|
-          response = Net::HTTPFound.new('2', code, 'Redirect')
-
-          allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-          allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-          expect(Net::HTTP).to receive(:request_get).with(
-            an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-            a_hash_including('range' => 'bytes=10-109')
-          )
+          stub = stub_request(:get, url)
+            .with(headers: { 'range' => 'bytes=10-109' })
+            .to_return(status: code)
 
           rio = described_class.new(url)
           rio.seek(10)
 
           expect { rio.read(100) }.to raise_error("Server at #{url} replied with a #{code}, indicating redirection; however, the location header was empty.")
+          expect(stub).to have_been_requested
         end
       end
-    end
 
-    context 'when the redirect limit is exceeded' do
-      it 'raises an error' do
-        url = 'https://images.invalid/my_image'
-        redirect_url = 'https://images.invalid/img.jpg'
+      context 'when the redirect limit is exceeded' do
+        it 'raises an error' do
+          redirecting_url = 'https://images.invalid/my_image'
+          destination_url = 'https://images.invalid/img.jpg'
 
-        {
-          '301' => Net::HTTPMovedPermanently,
-          '302' => Net::HTTPFound,
-          '303' => Net::HTTPSeeOther,
-          '307' => Net::HTTPTemporaryRedirect,
-          '308' => Net::HTTPPermanentRedirect,
-        }.each do |code, response_class|
-          response = response_class.new('2', code, 'Redirect')
-          response['location'] = redirect_url
+          stub = stub_request(:get, /https:\/\/images\.invalid.*/)
+            .with(headers: { 'range' => 'bytes=10-109' })
+            .to_return(headers: { 'location' => destination_url }, status: code)
 
-          allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-          allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-          expect(Net::HTTP).to receive(:request_get).with(
-            an_object_satisfying { |uri| URI::HTTPS === uri && uri.to_s == url },
-            a_hash_including('range' => 'bytes=10-109')
-          )
-
-          rio = described_class.new(url)
+          rio = described_class.new(redirecting_url)
           rio.seek(10)
-          expect { rio.read(100) }.to raise_error("Too many redirects; last one to: #{redirect_url}")
+
+          expect { rio.read(100) }.to raise_error("Too many redirects; last one to: #{destination_url}")
+          expect(stub).to have_been_requested.times(4)
         end
       end
     end
+
   end
 
   # 4XX
@@ -245,100 +195,77 @@ describe FormatParser::RemoteIO do
   context 'when the response status code is 416 (Range Not Satisfiable)' do
     it 'returns nil' do
       url = 'https://images.invalid/img.jpg'
-      response = Net::HTTPRangeNotSatisfiable.new('2', '416', 'Range Not Satisfiable')
 
-      allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-      allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-      expect(Net::HTTP).to receive(:request_get).with(
-        an_object_satisfying { |uri| uri.to_s == url },
-        a_hash_including('range' => 'bytes=100-199')
-      )
+      stub = stub_request(:get, url)
+        .with(headers: { 'range' => 'bytes=100-199' })
+        .to_return(status: 416)
 
       rio = described_class.new(url)
       rio.seek(100)
 
       expect(rio.read(100)).to be_nil
+      expect(stub).to have_been_requested
     end
 
     it 'does not change pos or size' do
       url = 'https://images.invalid/img.jpg'
-      first_response = Net::HTTPPartialContent.new('2', '206', 'Partial Content')
-      first_response['Content-Range'] = 'bytes 0-0/13'
-      allow(first_response).to receive(:body).and_return('Response body')
-      second_response = Net::HTTPRangeNotSatisfiable.new('2', '416', 'Range Not Satisfiable')
 
-      allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(first_response, second_response)
-      allow(Net::HTTP).to receive(:request_get).and_return(first_response, second_response)
-
-      expect(Net::HTTP).to receive(:request_get)
-        .with(
-          an_object_satisfying { |uri| uri.to_s == url },
-          a_hash_including('range' => 'bytes=0-0')
-        )
-        .ordered
-      expect(Net::HTTP).to receive(:request_get)
-        .with(
-          an_object_satisfying { |uri| uri.to_s == url },
-          a_hash_including('range' => 'bytes=100-199')
-        )
-        .ordered
+      stub = stub_request(:get, url)
+        .with(headers: { 'range' => 'bytes=0-0' })
+        .to_return(body: 'response body', headers: { 'Content-Range' => 'bytes 0-0/13' }, status: 206)
 
       rio = described_class.new(url)
       rio.read(1)
 
       expect(rio.size).to eq(13)
+      expect(stub).to have_been_requested
+
+      stub = stub_request(:get, url)
+        .with(headers: { 'range' => 'bytes=100-199' })
+        .to_return(status: 416)
 
       rio.seek(100)
       rio.read(100)
 
       expect(rio.pos).to eq(100)
       expect(rio.size).to eq(13)
+      expect(stub).to have_been_requested
     end
   end
 
-  context 'when the response status code is 4xx' do
-    it 'raises an error' do
-      url = 'https://images.invalid/img.jpg'
-      [*'400'..'415', *'417'..'499'].each do |code|
-        response = Net::HTTPClientError.new('2', code, 'Client Error')
+  [*400..415, *417..499].each do |code|
+    context "when the response status code is #{code}" do
+      it 'raises an error' do
+        url = 'https://images.invalid/img.jpg'
 
-        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-        allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-        expect(Net::HTTP).to receive(:request_get).with(
-          an_object_satisfying { |uri| uri.to_s == url },
-          a_hash_including('range' => 'bytes=100-199')
-        )
+        stub = stub_request(:get, url)
+          .with(headers: { 'range' => 'bytes=100-199' })
+          .to_return(status: code)
 
         rio = described_class.new(url)
         rio.seek(100)
 
         expect { rio.read(100) }.to raise_error("Server at #{url} replied with a #{code} and refused our request")
+        expect(stub).to have_been_requested
       end
     end
   end
 
   # 5XX
+  (500..599).each do |code|
+    context "when the response status code is #{code}" do
+      it 'raises an error' do
+        url = 'https://images.invalid/img.jpg'
 
-  context 'when the response status code is 5xx' do
-    it 'raises an error' do
-      url = 'https://images.invalid/img.jpg'
-      ('500'..'599').each do |code|
-        response = Net::HTTPServerError.new('2', code, 'Server Error')
-
-        allow(Net::HTTP).to receive(:start).and_yield(Net::HTTP).and_return(response)
-        allow(Net::HTTP).to receive(:request_get).and_return(response)
-
-        expect(Net::HTTP).to receive(:request_get).with(
-          an_object_satisfying { |uri| uri.to_s == url },
-          a_hash_including('range' => 'bytes=100-199')
-        )
+        stub = stub_request(:get, url)
+          .with(headers: { 'range' => 'bytes=100-199' })
+          .to_return(status: code)
 
         rio = described_class.new(url)
         rio.seek(100)
 
         expect { rio.read(100) }.to raise_error("Server at #{url} replied with a #{code} and we might want to retry")
+        expect(stub).to have_been_requested
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'rspec'
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
 require 'format_parser'
 
 module SpecHelpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,3 +30,5 @@ RSpec.shared_examples 'an IO object compatible with IOConstraint' do
     end
   end
 end
+
+RSpec::Matchers.define_negated_matcher :excluding, :include

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,5 +34,3 @@ RSpec.shared_examples 'an IO object compatible with IOConstraint' do
     end
   end
 end
-
-RSpec::Matchers.define_negated_matcher :excluding, :include


### PR DESCRIPTION
When Faraday would follow a redirect, by default, it would clear the `Authorization` header if the redirect location had a different host than the original request. This replicates that behaviour, the absence of which was causing S3 to respond with `InvalidArgument - Only one auth mechanism allowed` on Storm redirects.