### PR TITLE
[NO-JIRA] Persist Authorization Header After Redirect

### DIFF
--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.0.0.pre.3'
+  VERSION = '2.0.0.pre.4'
 end


### PR DESCRIPTION
There's a pretty niche issue with the implementation of redirect following, with respect to clearing the `Authorization` header after redirection to a different host. Suppose the following scenario:

1. We create a `RemoteIO` object with a certain URL and headers (including an `Authorization` header).
2. We call the `read` method which, internally, redirects us to another host. This means that we want to dispose of the `Authorization` header used in the initial request.
3. We call the `read` method again.

Previously, at step 3, we had an issue since we were deleting the `Authorization` header from the object's `@headers` field upon redirection to a different host. This meant that it would be missing for any subsequent reads by the same object, causing errors downstream. This PR ensures that the `Authorization` header is only disposed of for requests within a redirection chain, and will be persisted for any totally new requests.