### PR TITLE
2.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 2.0.0.pre.2 (Prerelease)
-* Drop support for Ruby `<2.7`.
+## 2.0.0
+* Drop explicit support for Ruby `<2.7`.
 * Drop faraday dependencies.
 * Loosen version constraints on other dependencies.
 * Update measurometer metrics for consistency and clarity.

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.0.0.pre.4'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
The pre-release has been deployed in Peek prod all day, all looks good! A very small job latency improvement (~10% quicker on average) and no discernible impact on parsing error rates. The big win is the reduction in log volume - without the deprecation warnings, we get ~half the number of error log messages that we otherwise would.

<img width="1364" alt="Screenshot 2022-11-03 at 16 06 39" src="https://user-images.githubusercontent.com/66637774/199774043-edd2a53b-51f6-401e-99b2-d0ab8e7dcb1e.png">
