### PR TITLE
chore: drop ks dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 2.6
           - 2.7
           - 3.0
           - 3.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 2.6
           - 2.7
           - 3.0
           - 3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+* Require minumum 2.7 ruby version.
+* Drop `ks` dependency.
+
 ## 2.0.0
 * Drop explicit support for Ruby `<2.7`.
 * Drop faraday dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.0
-* Require minumum 2.7 ruby version.
+* Require minumum 2.6 ruby version.
+* Bring back 2.6 to test matrix, we have jruby there which is still compatible with 2.6
 * Drop `ks` dependency.
 
 ## 2.0.0

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   minimum amount of data possible."
   spec.homepage      = 'https://github.com/WeTransfer/format_parser'
   spec.license       = 'MIT (Hippocratic)'
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'exifr', '>= 1.3.8'
   spec.add_dependency 'id3tag', '>= 0.14.2'
-  spec.add_dependency 'ks'
   spec.add_dependency 'measurometer'
 
   spec.add_development_dependency 'parallel_tests'

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   minimum amount of data possible."
   spec.homepage      = 'https://github.com/WeTransfer/format_parser'
   spec.license       = 'MIT (Hippocratic)'
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'

--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -1,10 +1,8 @@
-require 'ks'
-
 module FormatParser
   class Archive
     include FormatParser::AttributesJSON
 
-    class Entry < Ks.strict(:type, :size, :filename)
+    class Entry < Struct.new(:type, :size, :filename, keyword_init: true)
       def to_json(*a)
         to_h.to_json(*a)
       end

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.0.1'
+  VERSION = '2.1.0'
 end

--- a/lib/parsers/mp3_parser.rb
+++ b/lib/parsers/mp3_parser.rb
@@ -1,4 +1,3 @@
-require 'ks'
 require 'id3tag'
 
 class FormatParser::MP3Parser
@@ -6,13 +5,13 @@ class FormatParser::MP3Parser
 
   require_relative 'mp3_parser/id3_extraction'
 
-  class MPEGFrame < Ks.strict(:offset_in_file, :mpeg_id, :channels, :sample_rate, :frame_length, :frame_bitrate)
+  class MPEGFrame < Struct.new(:offset_in_file, :mpeg_id, :channels, :sample_rate, :frame_length, :frame_bitrate, keyword_init: true)
   end
 
-  class VBRHeader < Ks.strict(:frames, :byte_count, :toc_entries, :vbr_scale)
+  class VBRHeader < Struct.new(:frames, :byte_count, :toc_entries, :vbr_scale, keyword_init: true)
   end
 
-  class MP3Info < Ks.strict(:duration_seconds, :num_channels, :sampling_rate)
+  class MP3Info < Struct.new(:duration_seconds, :num_channels, :sampling_rate, keyword_init: true)
   end
 
   class InvalidDeepFetch < KeyError


### PR DESCRIPTION
Ruby 2.6 (our minimum required version) supports keyword_init for structs out of the box, we can drop the `ks` dependency now.