### PR TITLE
[CORE-199] Exclude CR3 from MOOV definition matching.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+* Bug fix for `CR3` files being misidentified as `MOOV`.
+
 ## 2.2.0
 * Add support for `CR3` files.
 * Add ISO base file format decoding functionality.

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/lib/parsers/moov_parser.rb
+++ b/lib/parsers/moov_parser.rb
@@ -107,12 +107,12 @@ class FormatParser::MOOVParser
   end
 
   # An MPEG4/MOV/M4A will start with the "ftyp" atom. The atom must have a length
-  # of at least 8 (to accomodate the atom size and the atom type itself) plus the major
+  # of at least 16 (to accomodate the atom size and the atom type itself) plus the major brand
   # and minor version fields. If we cannot find it we can be certain this is not our file.
   def matches_moov_definition?(io)
-    maybe_atom_size, maybe_ftyp_atom_signature = safe_read(io, 8).unpack('N1a4')
+    maybe_atom_size, maybe_ftyp_atom_signature, maybe_major_brand = safe_read(io, 12).unpack('N1a4a4')
     minimum_ftyp_atom_size = 4 + 4 + 4 + 4
-    maybe_atom_size >= minimum_ftyp_atom_size && maybe_ftyp_atom_signature == 'ftyp'
+    maybe_atom_size >= minimum_ftyp_atom_size && maybe_ftyp_atom_signature == 'ftyp' && maybe_major_brand != 'crx '
   end
 
   # Sample information is found in the 'time-to-sample' stts atom.

--- a/spec/parsers/moov_parser_spec.rb
+++ b/spec/parsers/moov_parser_spec.rb
@@ -135,4 +135,10 @@ describe FormatParser::MOOVParser do
     expect(result).not_to be_nil
     expect(result.format).to eq(:mov)
   end
+
+  it 'does not parse CR3 files' do
+    cr3_path = fixtures_dir + '/CR3/Canon EOS R10 (RAW).CR3'
+    result = subject.call(File.open(cr3_path, 'rb'))
+    expect(result).to be_nil
+  end
 end


### PR DESCRIPTION
CR3 files are being mididentified as MOOV files because they fit the defintion matching function and the CR3 parser has lower priority.