### PR TITLE
Single Frame Rate for MOV and MP4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.1
+* Revert change where variable frame rates in MOV and MP4 files would result in an array value for `frame_rate`.
+
 ## 2.4.0
 * Adapt the ISOBMFF based decoder for parsing MOV and MP4 parsing.
 * Fix MOV/MP4 issues:

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end

--- a/lib/parsers/iso_base_media_file_format/utils.rb
+++ b/lib/parsers/iso_base_media_file_format/utils.rb
@@ -45,7 +45,7 @@ module FormatParser::ISOBaseMediaFileFormat::Utils
   end
 
   def frame_rate(box_tree)
-    frame_rates = video_trak_boxes(box_tree).each_with_object([]) do |trak_box, frame_rates|
+    video_trak_boxes(box_tree).each_with_object([]) do |trak_box, frame_rates|
       mdia_box = trak_box['mdia']
       mdhd_box = mdia_box['mdhd']
       stts_box = mdia_box['minf']['stbl']['stts']
@@ -62,8 +62,7 @@ module FormatParser::ISOBaseMediaFileFormat::Utils
         # Variable frame rate
         frame_rates.push(*(stts_entries.map { |entry| frame_rate_for_entry[entry] }))
       end
-    end.uniq
-    frame_rates.length == 1 ? frame_rates[0] : frame_rates
+    end.uniq[0]
   end
 
   private

--- a/lib/parsers/iso_base_media_file_format/utils.rb
+++ b/lib/parsers/iso_base_media_file_format/utils.rb
@@ -63,6 +63,7 @@ module FormatParser::ISOBaseMediaFileFormat::Utils
         frame_rates.push(*(stts_entries.map { |entry| frame_rate_for_entry[entry] }))
       end
     end.uniq[0]
+    # TODO: Properly account for and represent variable frame-rates.
   end
 
   private


### PR DESCRIPTION
This PR reverts a change from 2.4.0 where variable frame rates in MOV and MP4 files would result in an array value for `frame_rate`.