### PR TITLE
Disable `udta` Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.5
+* Disable `udta` ISOBMFF box parsing, since their contents are not guaranteed to be consistent with the spec.
+
 ## 2.4.4
 * Prevent infinite loops when parsing ISOBMFF boxes with size = 0 (meaning that the box extends to the end of the file).
 

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.4.4'
+  VERSION = '2.4.5'
 end

--- a/lib/parsers/iso_base_media_file_format/decoder.rb
+++ b/lib/parsers/iso_base_media_file_format/decoder.rb
@@ -116,7 +116,7 @@ module FormatParser
         'trak' => :container,
         # 'trex' => :trex,
         # 'tsel' => :tsel,
-        'udta' => :container,
+        # 'udta' => :container,
         # 'url ' => :dref_url,
         # 'urn ' => :dref_urn,
         'uuid' => :uuid,


### PR DESCRIPTION
The User Data (`udta`) ISOBMFF box is currently treated as a standard container box, expecting other ISOBMFF boxes within. However, their contents don't always necesarily conform to the standard, resulting in some incorrect parsing, corrective buffer position updates and warning logs. This PR disables `udta` box parsing, which will skip parsing their contents.