### PR TITLE
add avc1 and xavc formats to mp4 parser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
           - jruby
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Gemfile Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Gemfile.lock
           key: ${{ runner.os }}-gemlock-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'format_parser.gemspec') }}
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-gemlock-${{ matrix.ruby }}-
       - name: Bundle Cache
         id: cache-gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'Gemfile.lock', 'format_parser.gemspec') }}
@@ -45,7 +45,7 @@ jobs:
         if: steps.cache-gems.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
       - name: Rubocop Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/rubocop_cache
           key: ${{ runner.os }}-rubocop-${{ hashFiles('.rubocop.yml') }}
@@ -68,13 +68,13 @@ jobs:
         experimental: [false]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Gemfile Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Gemfile.lock
           key: ${{ runner.os }}-gemlock-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'format_parser.gemspec') }}
@@ -82,7 +82,7 @@ jobs:
             ${{ runner.os }}-gemlock-${{ matrix.ruby }}-
       - name: Bundle Cache
         id: cache-gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'Gemfile.lock', 'format_parser.gemspec') }}

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'webrick'
   spec.add_development_dependency 'wetransfer_style', '1.0.0'
   spec.add_development_dependency 'yard'
-  spec.add_development_dependency 'webrick'
 end

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'wetransfer_style', '1.0.0'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'webrick'
 end

--- a/lib/parsers/mp4_parser.rb
+++ b/lib/parsers/mp4_parser.rb
@@ -5,7 +5,7 @@ class FormatParser::MP4Parser
   include FormatParser::ISOBaseMediaFileFormat
   include FormatParser::ISOBaseMediaFileFormat::Utils
 
-  MAGIC_BYTES = /^ftyp(iso[m2]|mp4[12]|m4[abprv]|avc1|xavc)$/i
+  MAGIC_BYTES = /^ftyp(iso[m2]|mp4[12]|m4[abprv] |avc1|xavc)$/i
 
   BRAND_FORMATS = {
     'isom' => :mp4, # Prohibited as a major brand by ISO/IEC 14496-12 sec 6.3 paragraph 2, but occasionally used.

--- a/lib/parsers/mp4_parser.rb
+++ b/lib/parsers/mp4_parser.rb
@@ -5,13 +5,15 @@ class FormatParser::MP4Parser
   include FormatParser::ISOBaseMediaFileFormat
   include FormatParser::ISOBaseMediaFileFormat::Utils
 
-  MAGIC_BYTES = /^ftyp(iso[m2]|mp4[12]|m4[abprv] )$/i
+  MAGIC_BYTES = /^ftyp(iso[m2]|mp4[12]|m4[abprv]|avc1|xavc)$/i
 
   BRAND_FORMATS = {
     'isom' => :mp4, # Prohibited as a major brand by ISO/IEC 14496-12 sec 6.3 paragraph 2, but occasionally used.
     'iso2' => :mp4, # Prohibited as a major brand by ISO/IEC 14496-12 sec 6.3 paragraph 2, but occasionally used.
     'mp41' => :mp4,
     'mp42' => :mp4,
+    'avc1' => :mp4,
+    'xavc' => :mp4, # Sony XAVC S
     'm4a ' => :m4a,
     'm4b ' => :m4b, # iTunes audiobooks
     'm4p ' => :m4p, # iTunes audio


### PR DESCRIPTION
The new sub formats (brands?) showed up in some of our use cases.

For now I have been unable to find test files with a license of the correct sub format of mp4 to be able to test these and validate my change works.

I added webrick as a dev dependency due to this causing errors in the [ruby 3.1 build](https://github.com/WeTransfer/format_parser/actions/runs/4936873971/jobs/8824943012). I found a related issue that suggests [webrick is no longer bundled in ruby 3.x and fixing it by adding it as a dependency](https://github.com/jekyll/jekyll/issues/8523). As we only use it in a test file I only added it as a dev dependency to keep the changes minimal. I'm not sure how this built successfully previously 🤔 

**UPDATE** Both myself and @rcpalacio have been unable to find any licensed test files. As we have some open issues in portal that this may fix I have discussed with Vanja that we would be ok to add this fix without specific test files and add these later if we find any.