### PR TITLE
Improving I/O consumption for TIFF-based formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.6.0
+* Prevent the default loading of thumbnails on TIFF-based formats to improve I/O.
+
 ## 2.5.0
 * Add `avc1` and `xavc` as brand codes in the mp4 format parser to allow more file types to be parsed correctly.
 

--- a/format_parser.gemspec
+++ b/format_parser.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'exifr', '>= 1.3.8'
+  spec.add_dependency 'exifr', '>= 1.4.0'
   spec.add_dependency 'id3tag', '>= 0.14.2'
   spec.add_dependency 'matrix'
   spec.add_dependency 'measurometer'

--- a/lib/format_parser/version.rb
+++ b/lib/format_parser/version.rb
@@ -1,3 +1,3 @@
 module FormatParser
-  VERSION = '2.5.0'
+  VERSION = '2.6.0'
 end

--- a/lib/parsers/exif_parser.rb
+++ b/lib/parsers/exif_parser.rb
@@ -175,7 +175,7 @@ module FormatParser::EXIFParser
   def exif_from_tiff_io(constrained_io, should_include_sub_ifds = false)
     Measurometer.instrument('format_parser.exif_parser.exif_from_tiff_io') do
       extended_io = IOExt.new(constrained_io)
-      exif_raw_data = EXIFR::TIFF.new(extended_io)
+      exif_raw_data = EXIFR::TIFF.new(extended_io, load_thumbnails: false)
 
       return unless exif_raw_data
 


### PR DESCRIPTION
All parsers for TIFF-based formats were loading embedded thumbnails alongside exif data, which was blowing the IO budget for large images.

This upgrades the dependency EXIFR that now allows us to skip this step.

(the actual work was done [here](https://github.com/remvee/exifr/pull/70))