### PR TITLE
Fixed failing integration test

### DIFF
--- a/spec/active_storage/rails_app_spec.rb
+++ b/spec/active_storage/rails_app_spec.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'spec_helper'
 
 def skip_reason
@@ -10,14 +11,14 @@ def skip_reason
   end
 end
 
-# TODO: Investigate and fix this test
-describe 'Rails app with ActiveStorage and format-parser', skip: skip_reason do
+describe 'Rails app with ActiveStorage and format-parser' do
   describe 'local hosting with ActiveStorage disk adapter' do
     it 'parse local file with format_parser' do
       clean_env do
         cmd = 'ruby spec/integration/active_storage/rails_app.rb'
         cmd_status = ruby_script_runner(cmd)
-        expect(cmd_status[:stdout].last).to match(/1 runs, 3 assertions, 0 failures, 0 errors, 0 skips/)
+        printout = cmd_status[:stdout].last
+        expect(printout).to match(/1 runs, 3 assertions, 0 failures, 0 errors, 0 skips/)
         expect(cmd_status[:exitstatus]).to eq(0)
       end
     end


### PR DESCRIPTION
The integration test "Rails app with ActiveStorage and format-parser" uses the [Open3 module](https://www.rubydoc.info/stdlib/open3/Open3) to start a new child process running this command: `ruby spec/integration/active_storage/rails_app.rb`. The stdout from this child process is captured line by line in an array. Once the child process has finished, our test checks the last output line from that array, and expects it to match this value: “1 runs, 3 assertions, 0 failures, 0 errors, 0 skips”.

When running this via terminal, I was getting this error:
```
Rails app with ActiveStorage and format-parser local hosting with ActiveStorage disk adapter parse local file with format_parser
     Failure/Error: if Bundler.respond_to?(:with_unbundled_env)
     NameError:
       uninitialized constant Bundler
```

This change fixes the issue by following the recommendation in [this Ruby guide](https://bundler.io/guides/bundler_setup.html) and adding this line at the top of the test file: require 'bundler/setup'.